### PR TITLE
fix: Add text attribute to ReformatWithBiomeAction

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -46,7 +46,7 @@
               topic="com.intellij.openapi.vfs.newvfs.BulkFileListener"/>
   </projectListeners>
   <actions>
-    <action id="ReformatWithBiomeAction" class="com.github.biomejs.intellijbiome.actions.ReformatWithBiomeAction">
+    <action id="ReformatWithBiomeAction" text="Reformat with Biome" class="com.github.biomejs.intellijbiome.actions.ReformatWithBiomeAction">
       <add-to-group group-id="EditorPopupMenu" anchor="last"/>
       <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
       <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt shift P"/>


### PR DESCRIPTION
this fixes #33

The error appeared because the text attribute was missing in the action. The action now appears in the menu.

![image](https://github.com/biomejs/biome-intellij/assets/103201879/04ad31dc-44e4-4e05-b783-ed65de0201d4)

