### PR TITLE
add .vue,.svelte,.astro to default files

### DIFF
--- a/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeSettingsState.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeSettingsState.kt
@@ -23,6 +23,6 @@ class BiomeSettingsState : BaseState() {
     var configurationMode by enum(ConfigurationMode.AUTOMATIC)
 
     companion object {
-        const val DEFAULT_FILE_PATTERN = "**/*.{js,mjs,cjs,ts,jsx,tsx,cts,json,jsonc}"
+        const val DEFAULT_FILE_PATTERN = "**/*.{js,mjs,cjs,ts,jsx,tsx,cts,json,jsonc,vue,svelte,astro}"
     }
 }


### PR DESCRIPTION
since 1.6 .vue .svelte and .astro are [partially supported](https://biomejs.dev/internals/language-support/#html-super-languages-support)

when running biome on all files these files now get formatted and linted but the plugin just ignores them.
which is kinda confusing.

Thanks for the great work!