### PR TITLE
allow intellij project to work with different biome configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ The plugin tries to use Biome from your project’s local dependencies (`node_mo
 
 You can also explicitly specify the `biome` binary the extension should use by configuring the `Biome CLI Path` in `Settings`->`Language & Frameworks`->`Biome Settings`.
 
+### Biome Config resolution
+In `Automatic Biome configuration` mode, the plugin will look for a biome configuration file upwards from the current file. If it doesn't find one, it will stop LSP server.
+There are several reasons to behave like this:
+1. In IDEA with multiple projects in one code base it sound reasonable to disable LSP server if there is no biome configuration file in the project.
+2. In multi-root workspace, we should run biome from proper working directory, so that `include` and `exclude` paths are resolved correctly.
+3. As currently LSP server proxy doesn't provide option to work with multiple configs, we should provide path to the biome configuration file and restart LSP server once active file is changed.
+
 ### Plugin settings
 
 #### `Biome CLI Path`

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/BiomeStdinRunner.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/BiomeStdinRunner.kt
@@ -48,8 +48,8 @@ class BiomeStdinRunner(private val project: Project) : BiomeRunner {
     }
 
     override fun createCommandLine(file: VirtualFile, action: String, args: List<String>): GeneralCommandLine {
-        val configPath = biomePackage.configPath
-        val exePath = biomePackage.binaryPath()
+        val configPath = biomePackage.configPath(file)
+        val exePath = biomePackage.binaryPath(configPath, false)
         val params = SmartList(action, "--stdin-file-path", file.path)
         params.addAll(args)
 
@@ -64,6 +64,7 @@ class BiomeStdinRunner(private val project: Project) : BiomeRunner {
 
         return GeneralCommandLine().runBiomeCLI(project, exePath).apply {
             withInput(File(file.path))
+            withWorkDirectory(configPath)
             addParameters(params)
         }
     }

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/actions/BiomeCheckOnSaveAction.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/actions/BiomeCheckOnSaveAction.kt
@@ -1,41 +1,21 @@
 package com.github.biomejs.intellijbiome.actions
 
-import com.github.biomejs.intellijbiome.Feature
 import com.github.biomejs.intellijbiome.settings.BiomeSettings
 import com.intellij.ide.actionsOnSave.impl.ActionsOnSaveFileDocumentManagerListener
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.project.Project
-import java.util.*
 
 
 class BiomeCheckOnSaveAction() :
     ActionsOnSaveFileDocumentManagerListener.ActionOnSave() {
-    private var features: EnumSet<Feature> = EnumSet.noneOf(Feature::class.java)
     override fun isEnabledForProject(project: Project): Boolean {
         val settings = BiomeSettings.getInstance(project)
-
-        setFeatures(settings)
 
         return settings.formatOnSave || settings.applySafeFixesOnSave || settings.applyUnsafeFixesOnSave
     }
 
     override fun processDocuments(project: Project, documents: Array<Document>) {
-        BiomeCheckRunner().run(project, features, documents)
-    }
-
-    private fun setFeatures(settings: BiomeSettings) {
-        features = EnumSet.noneOf(Feature::class.java)
-
-        if (settings.formatOnSave) {
-            features.add(Feature.Format)
-        }
-
-        if (settings.applySafeFixesOnSave) {
-            features.add(Feature.SafeFixes)
-        }
-
-        if (settings.applyUnsafeFixesOnSave) {
-            features.add(Feature.UnsafeFixes)
-        }
+        val settings = BiomeSettings.getInstance(project)
+        BiomeCheckRunner().run(project, settings.getEnabledFeatures(), documents)
     }
 }

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/actions/ReformatWithBiomeAction.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/actions/ReformatWithBiomeAction.kt
@@ -1,14 +1,13 @@
 package com.github.biomejs.intellijbiome.actions
 
-import com.github.biomejs.intellijbiome.Feature
 import com.github.biomejs.intellijbiome.settings.BiomeSettings
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.DumbAware
-import java.util.*
 
 
 class ReformatWithBiomeAction : AnAction(), DumbAware {
@@ -19,7 +18,13 @@ class ReformatWithBiomeAction : AnAction(), DumbAware {
         val editor: Editor? = actionEvent.getData(CommonDataKeys.EDITOR)
 
         if (editor != null) {
-            BiomeCheckRunner().run(project, EnumSet.of(Feature.Format), arrayOf(editor.document))
+            val documentManager = FileDocumentManager.getInstance()
+            // We should save document before running Biome, because Biome will read the file from disk and user changes can be lost
+            if (documentManager.isDocumentUnsaved(editor.document)) {
+                documentManager.saveDocument(editor.document)
+            }
+            val settings = BiomeSettings.getInstance(project)
+            BiomeCheckRunner().run(project, settings.getEnabledFeatures(), arrayOf(editor.document))
         }
     }
 

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/listeners/BiomeEditorPanelListener.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/listeners/BiomeEditorPanelListener.kt
@@ -1,0 +1,39 @@
+package com.github.biomejs.intellijbiome.listeners
+
+import com.github.biomejs.intellijbiome.BiomePackage
+import com.github.biomejs.intellijbiome.services.BiomeServerService
+import com.github.biomejs.intellijbiome.settings.BiomeSettings
+import com.intellij.openapi.components.service
+import com.intellij.openapi.fileEditor.FileEditorManagerEvent
+import com.intellij.openapi.fileEditor.FileEditorManagerListener
+import com.intellij.openapi.project.Project
+
+class BiomeEditorPanelListener(private val project: Project) : FileEditorManagerListener {
+
+    private var currentConfigPath: String? = null
+
+    // on selection change, check if the new file should not use different biome config.
+    // if so, restart biome server to use the new config.
+    override fun selectionChanged(fileEditorManagerEvent: FileEditorManagerEvent) {
+        val settings = BiomeSettings.getInstance(project)
+        val isEnabled = settings.isEnabled()
+        if (fileEditorManagerEvent.newFile != null) {
+            val newConfigPath = BiomePackage(project).configPath(fileEditorManagerEvent.newFile!!)
+            val biomeServerService = project.service<BiomeServerService>()
+            // stop biome LSP server if selected file does not have biome config.
+            if (newConfigPath == null) {
+                currentConfigPath = null
+                biomeServerService.stopBiomeServer()
+                return
+            }
+            if (isEnabled && currentConfigPath != newConfigPath) {
+                currentConfigPath = newConfigPath
+                biomeServerService.restartBiomeServer()
+            }
+        }
+    }
+
+    fun getCurrentConfigPath(): String? {
+        return currentConfigPath
+    }
+}

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/services/BiomeServerService.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/services/BiomeServerService.kt
@@ -1,17 +1,38 @@
 package com.github.biomejs.intellijbiome.services
 
 import com.github.biomejs.intellijbiome.BiomeBundle
+import com.github.biomejs.intellijbiome.listeners.BiomeEditorPanelListener
+import com.github.biomejs.intellijbiome.lsp.BiomeLspServerManagerListener
 import com.github.biomejs.intellijbiome.lsp.BiomeLspServerSupportProvider
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.components.Service
+import com.intellij.openapi.fileEditor.FileEditorManagerListener
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
 import com.intellij.platform.lsp.api.LspServerManager
 
 @Service(Service.Level.PROJECT)
 class BiomeServerService(private val project: Project) {
+    private val editorPanelListener: BiomeEditorPanelListener
+
+    init {
+        addBiomeLspListener()
+        editorPanelListener = BiomeEditorPanelListener(project)
+        project.messageBus.connect().subscribe(FileEditorManagerListener.FILE_EDITOR_MANAGER, editorPanelListener)
+    }
+
+    fun getCurrentConfigPath(): String? {
+        return editorPanelListener.getCurrentConfigPath()
+    }
+
     fun restartBiomeServer() {
         LspServerManager.getInstance(project).stopAndRestartIfNeeded(BiomeLspServerSupportProvider::class.java)
+    }
+
+    fun addBiomeLspListener() {
+        LspServerManager.getInstance(project)
+            .addLspServerManagerListener(BiomeLspServerManagerListener(project), Disposer.newDisposable(), true)
     }
 
     fun stopBiomeServer() {

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeSettings.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeSettings.kt
@@ -1,10 +1,12 @@
 package com.github.biomejs.intellijbiome.settings
 
+import com.github.biomejs.intellijbiome.Feature
 import com.intellij.lang.javascript.linter.GlobPatternUtil
 import com.intellij.openapi.components.*
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import java.io.File
+import java.util.*
 
 
 @Service(Service.Level.PROJECT)
@@ -56,6 +58,20 @@ class BiomeSettings :
         set(value) {
             state.applyUnsafeFixesOnSave = value
         }
+
+    fun getEnabledFeatures(): EnumSet<Feature> {
+        val features = EnumSet.noneOf(Feature::class.java)
+        if (formatOnSave) {
+            features.add(Feature.Format)
+        }
+        if (applySafeFixesOnSave) {
+            features.add(Feature.SafeFixes)
+        }
+        if (applyUnsafeFixesOnSave) {
+            features.add(Feature.UnsafeFixes)
+        }
+        return features
+    }
 
     fun isEnabled(): Boolean {
         return configurationMode !== ConfigurationMode.DISABLED


### PR DESCRIPTION
Hi

I really liked the speed and easy use of biome. But unfortunately without pretty support in IDE it's really hard to bring it to my company now. So I tried to solve current issues, that block.

1. https://github.com/biomejs/biome-intellij/issues/44
The problem is that in case if file wasn't saved first, it was deleted entirely. Also I think it should be valid to use all options (applySafeFixesOnSave, applyUnsafeFixesOnSave) when Reformat with Biome is triggered, cause this is something that everyone expect.

2. https://github.com/biomejs/biome-intellij/issues/42
This is done for Automatic setup. I didn't come up with something better, that lookup to biome config from file upwards the project root. So it will use this file as config for formatting and LSP then. LSP will restart, if editor will be focused on newfile that will have different biome config. I saw this issue in main biome https://github.com/biomejs/biome/issues/1573. But currently LSP proxy is not supporting workspaces. Also for me workspaces looks less flexible, as for example I can specify several biome conf now in one workspace (let's say for different folders for some reasons). Also as in large codebases there could be the case, that biome will be enabled not on root level, I stop LSP in cases, if there is no biome config. Otherwise it can create noise to some other projects within your workspace.