### PR TITLE
Revert "Add support for RustRover"

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -18,7 +18,7 @@
 
   <depends>com.intellij.modules.platform</depends>
   <depends>com.intellij.modules.ultimate</depends>
-  <depends>com.intellij.modules.javascript</depends>
+  <depends>JavaScript</depends>
 
   <resource-bundle>messages.BiomeBundle</resource-bundle>
 


### PR DESCRIPTION
JetBrains does not seem to recognize `com.intellij.modules.javascript` as compatible with all their IDEs except IntelliJ Ultimate. It works perfectly fine when installed over disk, but the latest version on the store for Webstorm and most IDEs is still 1.1.0.

Reverts biomejs/biome-intellij#57