### PR TITLE
fix: upload build artifact

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -68,4 +68,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Biome-${{ steps.version.outputs.version }}.zip
-          path: build/distributions/Biome-${{ steps.version.outputs.version }}.zip
+          path: build/distributions/intellij-biome-${{ steps.version.outputs.version }}.zip


### PR DESCRIPTION
Due the migration to  intellj plugin platform the build path/filename changed from `build/distributions/Biome-1.2.0.zip` to `build/distributions/intellij-biome-1.2.1.zip`.

If i understand the release pipeline correctly, it builds the plugin and upload the artifacts for the next steps. So i only need to upload `intellij-biome-x.y.z.zip` as `Biome-x.y.z.zip`.

@ematipico I don't know to test the github actions. Maybe you can run the nighly-release-actions based on this branch before merge? I'm sorry that this release needs three PRs (until now :crossed_fingers:).