### PR TITLE
chore(release): setup java and gradle, display structure of downloaded artifact(s)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,6 +28,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-home-cache-cleanup: true
+
       - name: Download the artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -75,6 +75,9 @@ jobs:
         with:
           name: Biome-${{ needs.build.outputs.version }}.zip
 
+      - name: Display structure of downloaded files
+        run: ls -R
+
       - name: Generate release notes
         id: release-notes
         uses: orhun/git-cliff-action@v2


### PR DESCRIPTION
## Setup java and gradle

Setup java and gradle should fix error: https://github.com/biomejs/biome-intellij/actions/runs/10491164584/job/29059934829

> [!CAUTION]
> Dependency requires at least JVM runtime version 17. This build uses a Java 11 JVM.

https://github.com/biomejs/biome-intellij/blob/67c2c5cc004f3862c53cccd14cd8e8133242704b/.github/workflows/publish.yaml#L31-L40

Source: https://github.com/JetBrains/intellij-platform-plugin-template/blob/main/.github/workflows/release.yml

## Display downloaded files

Display downloaded files to debug error: https://github.com/biomejs/biome-intellij/actions/runs/10491164584/job/29059934508

> [!CAUTION]
> Run mv "Biome-1.2.1-nightly.9b01429.zip" biome.zip
> mv: cannot stat 'Biome-1.2.1-nightly.9b01[4](https://github.com/biomejs/biome-intellij/actions/runs/10491164584/job/29059934508#step:7:5)29.zip': No such file or directory
> Error: Process completed with exit code 1.

https://github.com/biomejs/biome-intellij/blob/67c2c5cc004f3862c53cccd14cd8e8133242704b/.github/workflows/publish.yaml#L42-L45