### PR TITLE
fix(release): rename artifact with "intellij-biome-" instead "Biome-" prefix

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -75,9 +75,6 @@ jobs:
         with:
           name: Biome-${{ needs.build.outputs.version }}.zip
 
-      - name: Display structure of downloaded files
-        run: ls -R
-
       - name: Generate release notes
         id: release-notes
         uses: orhun/git-cliff-action@v2
@@ -91,7 +88,7 @@ jobs:
         run: tail -n +3 < CHANGES.md > RELEASE_NOTES.md
 
       - name: Rename artifact
-        run: mv "Biome-${{ needs.build.outputs.version }}.zip" biome.zip
+        run: mv "intellij-biome-${{ needs.build.outputs.version }}.zip" biome.zip
 
       - name: Publish extension to GitHub Releases
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
I don't know why, but the downloaded ZIP file has the prefix "intellij-biome-" instead of "Biome-" in GitHub Action "Publish to GitHub Releases":
https://github.com/biomejs/biome-intellij/actions/runs/10522456811/job/29155394740#step:5:17

Based on the github action log, I would have expected "Biome-": 
https://github.com/biomejs/biome-intellij/actions/runs/10522456811/job/29155135022#step:10:23

When I download the artifact on my system, I get the file with a "Biome-" prefix: 
https://github.com/biomejs/biome-intellij/actions/runs/10522456811/artifacts/1846129195