### PR TITLE
feat: set flags based on biome-version to add backwards compatibility

### DIFF
--- a/src/main/kotlin/com/github/biomejs/intellijbiome/BiomePackage.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/BiomePackage.kt
@@ -92,4 +92,24 @@ class BiomePackage(private val project: Project) {
         }
         return null
     }
+
+    fun compareVersion(version1: String, version2: String): Int {
+        val parts1 = version1.split(".").map { it.toInt() }
+        val parts2 = version2.split(".").map { it.toInt() }
+
+        val maxLength = maxOf(parts1.size, parts2.size)
+
+        for (i in 0 until maxLength){
+            val v1 = if (i < parts1.size) parts1[i] else 0
+            val v2 = if (i < parts2.size) parts2[i] else 0
+
+            when {
+                v1 < v2 -> return -1
+                v1 > v2 -> return 1
+            }
+        }
+
+        return 0
+    }
+
 }

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/BiomeRunner.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/BiomeRunner.kt
@@ -20,7 +20,7 @@ interface BiomeRunner {
         val DEFAULT_TIMEOUT = 30000.milliseconds
     }
 
-    fun check(request: Request, features: EnumSet<Feature>): Response
+    fun check(request: Request, features: EnumSet<Feature>, biomePackage: BiomePackage): Response
     fun createCommandLine(file: VirtualFile, action: String, args: List<String> = listOf()): GeneralCommandLine
 
 

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/actions/BiomeCheckRunner.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/actions/BiomeCheckRunner.kt
@@ -1,9 +1,6 @@
 package com.github.biomejs.intellijbiome.actions
 
-import com.github.biomejs.intellijbiome.BiomeBundle
-import com.github.biomejs.intellijbiome.BiomeRunner
-import com.github.biomejs.intellijbiome.BiomeStdinRunner
-import com.github.biomejs.intellijbiome.Feature
+import com.github.biomejs.intellijbiome.*
 import com.github.biomejs.intellijbiome.settings.BiomeSettings
 import com.intellij.lang.javascript.linter.GlobPatternUtil
 import com.intellij.openapi.command.WriteCommandAction
@@ -40,6 +37,7 @@ class BiomeCheckRunner {
         val runner = BiomeStdinRunner(project)
         val manager = FileDocumentManager.getInstance()
         val settings = BiomeSettings.getInstance(project)
+        val biomePackage = BiomePackage(project)
         val requests = documents
             .mapNotNull { document -> manager.getFile(document)?.let { document to it } }
             .filter { GlobPatternUtil.isFileMatchingGlobPattern(project, settings.filePattern, it.second) }
@@ -52,7 +50,7 @@ class BiomeCheckRunner {
                         indicator.text = commandDescription
 
                         requests.forEach { request ->
-                            val response = runner.check(request, features)
+                            val response = runner.check(request, features, biomePackage)
 
                             if (!indicator.isCanceled) {
                                 applyChanges(project, request, response)


### PR DESCRIPTION
Since [Biome v1.8.0](https://github.com/biomejs/biome/blob/main/CHANGELOG.md#180-2024-06-04) the cli arguments have changed from `--apply` and `--apply-unsafe` to `--write` and `--unsafe`.

In https://github.com/biomejs/biome-intellij/pull/85 we updated the cli flags, but dropped backwards compatibility.

This PR checks the running biome version to add backwards compatibility to biome prior to 1.8.0. This PR also sets `--skip-errors` to skip files containing syntax errors instead of throw an error.

Fixes #89 #90 #95