### PR TITLE
chore: Normalize line separators in BiomeCheckRunner updates

### DIFF
--- a/src/main/kotlin/com/github/biomejs/intellijbiome/actions/BiomeCheckRunner.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/actions/BiomeCheckRunner.kt
@@ -79,10 +79,11 @@ class BiomeCheckRunner(
             is BiomeRunner.Response.Success -> {
                 val text = response.code
                 val lineSeparator = StringUtil.detectSeparators(text)
-
+                // internally we keep newlines as \n
+                val normalizedText = StringUtil.convertLineSeparators(text)
                 writeCommandAction(project, request.commandDescription) {
-                    if (!StringUtil.equals(request.document.text, text)) {
-                        request.document.setText(text)
+                    if (!StringUtil.equals(request.document.charsSequence, normalizedText)) {
+                        request.document.setText(normalizedText)
                     }
 
                     setDetectedLineSeparator(project, request.virtualFile, lineSeparator)


### PR DESCRIPTION
Fix https://github.com/biomejs/biome-intellij/issues/108

we need to normalize saving text with `lf`