### PR TITLE
fix: support running Biome on WSL Node.js interpreter

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ pluginUntilBuild = 243.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = WS
-platformVersion = 2024.3
+platformVersion = 2024.3.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/BiomePackage.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/BiomePackage.kt
@@ -93,7 +93,11 @@ class BiomePackage(private val project: Project) {
         }
 
         val processHandler =
-            BiomeTargetRunBuilder(project).getBuilder(binaryPath).addParameters(listOf("--version")).build()
+            BiomeTargetRunBuilder(project)
+                .getBuilder(binaryPath)
+                .addParameters(listOf(ProcessCommandParameter.Value("--version")))
+                .build()
+
         return runCatching {
             val result = runProcessFuture(processHandler).await()
             val processOutput = result.processOutput

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/GeneralProcessCommandBuilder.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/GeneralProcessCommandBuilder.kt
@@ -29,8 +29,9 @@ class GeneralProcessCommandBuilder : ProcessCommandBuilder {
         return this
     }
 
-    override fun addParameters(params: List<String>): ProcessCommandBuilder {
-        parameters.addAll(params)
+    override fun addParameters(params: List<ProcessCommandParameter>): ProcessCommandBuilder {
+        // TODO: custom executable is not supported in WSL yet
+        parameters.addAll(params.map { it.toString() })
         return this
     }
 

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/NodeProcessCommandBuilder.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/NodeProcessCommandBuilder.kt
@@ -33,8 +33,13 @@ class NodeProcessCommandBuilder(
         return this
     }
 
-    override fun addParameters(params: List<String>): ProcessCommandBuilder {
-        parameters.addAll(params)
+    override fun addParameters(params: List<ProcessCommandParameter>): ProcessCommandBuilder {
+        parameters.addAll(params.map {
+            when (it) {
+                is ProcessCommandParameter.Value -> it.value
+                is ProcessCommandParameter.FilePath -> target.convertLocalPathToTargetPath(it.path)
+            }
+        })
         return this
     }
 

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/ProcessCommandBuilder.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/ProcessCommandBuilder.kt
@@ -7,7 +7,7 @@ import java.nio.charset.Charset
 interface ProcessCommandBuilder {
     fun setWorkingDirectory(path: String?): ProcessCommandBuilder
     fun setInputFile(file: VirtualFile?): ProcessCommandBuilder
-    fun addParameters(params: List<String>): ProcessCommandBuilder
+    fun addParameters(params: List<ProcessCommandParameter>): ProcessCommandBuilder
     fun setExecutable(executable: String): ProcessCommandBuilder
     fun setCharset(charset: Charset): ProcessCommandBuilder
     fun build(): OSProcessHandler

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/ProcessCommandParameter.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/ProcessCommandParameter.kt
@@ -1,0 +1,22 @@
+package com.github.biomejs.intellijbiome
+
+/**
+ * A command argument for creating a process.
+ */
+sealed interface ProcessCommandParameter {
+    /**
+     * A raw string value.
+     * No conversion will be applied on any environment.
+     */
+    class Value(val value: String) : ProcessCommandParameter {
+        override fun toString() = value
+    }
+
+    /**
+     * A file path value which points any file or directory on the execution environment.
+     * For example, the path will be converted automatically when running Node.js on WSL 2.
+     */
+    class FilePath(val path: String) : ProcessCommandParameter {
+        override fun toString() = path
+    }
+}

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/lsp/BiomeLspServerSupportProvider.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/lsp/BiomeLspServerSupportProvider.kt
@@ -3,6 +3,7 @@ package com.github.biomejs.intellijbiome.lsp
 import com.github.biomejs.intellijbiome.BiomeIcons
 import com.github.biomejs.intellijbiome.BiomePackage
 import com.github.biomejs.intellijbiome.BiomeTargetRunBuilder
+import com.github.biomejs.intellijbiome.ProcessCommandParameter
 import com.github.biomejs.intellijbiome.services.BiomeServerService
 import com.github.biomejs.intellijbiome.settings.BiomeConfigurable
 import com.github.biomejs.intellijbiome.settings.BiomeSettings
@@ -57,10 +58,10 @@ import com.intellij.util.SmartList
     }
 
     override fun startServerProcess(): OSProcessHandler {
-        val params = SmartList("lsp-proxy")
+        val params = SmartList<ProcessCommandParameter>(ProcessCommandParameter.Value("lsp-proxy"))
         if (!configPath.isNullOrEmpty()) {
-            params.add("--config-path")
-            params.add(configPath)
+            params.add(ProcessCommandParameter.Value("--config-path"))
+            params.add(ProcessCommandParameter.FilePath(configPath))
         }
 
         return targetRunBuilder.getBuilder(executable).apply {


### PR DESCRIPTION
Closes #49 

This pull request adds support for running Biome on Node.js interpreter on WSL 2.
IntelliJ's Node.js execution supports converting a local path to WSL path or vice versa.

Reproduction steps:

1. Install a distribution on WSL 2.
2. Install WebStorm on Windows (do not use JetBrains Gateway).
3. Setup Node.js interpreter that runs on WSL 2:
   <img width="781" alt="image" src="https://github.com/user-attachments/assets/5c7c3e21-f697-487e-9532-1605f87374dc" />
4. Install Biome plugin.
5. Open a project that has `biome.json`.