### PR TITLE
fix: convert WSL path to local path and vice versa

### DIFF
--- a/src/main/kotlin/com/github/biomejs/intellijbiome/BiomePackage.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/BiomePackage.kt
@@ -97,6 +97,7 @@ class BiomePackage(private val project: Project) {
                 .getBuilder(binaryPath)
                 .addParameters(listOf(ProcessCommandParameter.Value("--version")))
                 .build()
+                .startProcess()
 
         return runCatching {
             val result = runProcessFuture(processHandler).await()

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/GeneralProcessCommandBuilder.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/GeneralProcessCommandBuilder.kt
@@ -2,10 +2,7 @@ package com.github.biomejs.intellijbiome
 
 import com.intellij.execution.ExecutionException
 import com.intellij.execution.configurations.GeneralCommandLine
-import com.intellij.execution.process.CapturingProcessHandler
-import com.intellij.execution.process.OSProcessHandler
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.util.io.BaseOutputReader
 import java.io.File
 import java.nio.charset.Charset
 import kotlin.io.path.Path
@@ -45,7 +42,7 @@ class GeneralProcessCommandBuilder : ProcessCommandBuilder {
         return this
     }
 
-    override fun build(): OSProcessHandler {
+    override fun build(): BiomeTargetRun {
         val exec = executable ?: throw ExecutionException(BiomeBundle.message("biome.language.server.not.found"))
 
         command.withExePath(exec)
@@ -54,14 +51,6 @@ class GeneralProcessCommandBuilder : ProcessCommandBuilder {
         command.addParameters(parameters)
         charset?.let { command.withCharset(it) }
 
-        return object : CapturingProcessHandler(command) {
-            override fun readerOptions(): BaseOutputReader.Options {
-                return object : BaseOutputReader.Options() {
-                    // This option ensures that line separators are not converted to LF
-                    // when the formatter sends e.g., CRLF
-                    override fun splitToLines(): Boolean = false
-                }
-            }
-        }
+        return BiomeTargetRun.General(command)
     }
 }

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/NodeProcessCommandBuilder.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/NodeProcessCommandBuilder.kt
@@ -1,7 +1,6 @@
 package com.github.biomejs.intellijbiome
 
 import com.intellij.execution.ExecutionException
-import com.intellij.execution.process.OSProcessHandler
 import com.intellij.execution.target.value.TargetValue
 import com.intellij.javascript.nodejs.execution.NodeTargetRun
 import com.intellij.javascript.nodejs.execution.NodeTargetRunOptions.Companion.of
@@ -53,7 +52,7 @@ class NodeProcessCommandBuilder(
         return this
     }
 
-    override fun build(): OSProcessHandler {
+    override fun build(): BiomeTargetRun {
         val exec = executable ?: throw ExecutionException(BiomeBundle.message("biome.language.server.not.found"))
 
         workingDir?.let { builder.setWorkingDirectory(target.path(it)) }
@@ -62,7 +61,6 @@ class NodeProcessCommandBuilder(
         inputFile?.let { builder.setInputFile(TargetValue.fixed(it.path)) }
         charset?.let { builder.charset = it }
 
-        val process = target.startProcessEx()
-        return process.processHandler
+        return BiomeTargetRun.Node(target)
     }
 }

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/ProcessCommandBuilder.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/ProcessCommandBuilder.kt
@@ -1,6 +1,5 @@
 package com.github.biomejs.intellijbiome
 
-import com.intellij.execution.process.OSProcessHandler
 import com.intellij.openapi.vfs.VirtualFile
 import java.nio.charset.Charset
 
@@ -10,5 +9,5 @@ interface ProcessCommandBuilder {
     fun addParameters(params: List<ProcessCommandParameter>): ProcessCommandBuilder
     fun setExecutable(executable: String): ProcessCommandBuilder
     fun setCharset(charset: Charset): ProcessCommandBuilder
-    fun build(): OSProcessHandler
+    fun build(): BiomeTargetRun
 }

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/lsp/BiomeLspServerSupportProvider.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/lsp/BiomeLspServerSupportProvider.kt
@@ -8,7 +8,6 @@ import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.OSProcessHandler
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.lsp.api.LspServer
 import com.intellij.platform.lsp.api.LspServerSupportProvider
@@ -16,7 +15,6 @@ import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor
 import com.intellij.platform.lsp.api.customization.LspFormattingSupport
 import com.intellij.platform.lsp.api.lsWidget.LspServerWidgetItem
 import com.intellij.util.SmartList
-import kotlin.io.path.Path
 
 
 @Suppress("UnstableApiUsage") class BiomeLspServerSupportProvider : LspServerSupportProvider {
@@ -75,7 +73,7 @@ import kotlin.io.path.Path
         targetRun.toTargetPath(file.path)
 
     override fun findLocalFileByPath(path: String): VirtualFile? =
-        VfsUtil.findFile(Path(targetRun.toLocalPath(path)), true)
+        super.findLocalFileByPath(targetRun.toLocalPath(path))
 
     override val lspGoToDefinitionSupport = false
     override val lspCompletionSupport = null


### PR DESCRIPTION
Follow-up of #131
Closes #72
Closes #83

By the fix above, Biome now runs on WSL successfully. However no diagnostics are shown on the editor. Biome responses diagnostics with their file path on LSP, and it is needed to convert the file path on WSL to local path. I added `findLocalFileByPath` implementation in `BiomeLspServerDescriptor` with some refactorings around `BiomeTargetRun`.