### PR TITLE
feat: support workspace/configuration request for providing configuration path

### DIFF
--- a/sandbox/bar/package.json
+++ b/sandbox/bar/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "packageManager": "pnpm@10.5.2",
   "devDependencies": {
-    "@biomejs/biome": "1.9.4"
+    "@biomejs/biome": "https://pkg.pr.new/biomejs/biome/@biomejs/biome@1c3707dafd1337582538c336113d621558e4c176"
   },
   "scripts": {
     "check": "biome check"

--- a/sandbox/foo/package.json
+++ b/sandbox/foo/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "packageManager": "pnpm@10.5.2",
   "devDependencies": {
-    "@biomejs/biome": "1.9.4"
+    "@biomejs/biome": "https://pkg.pr.new/biomejs/biome/@biomejs/biome@1c3707dafd1337582538c336113d621558e4c176"
   },
   "scripts": {
     "check": "biome check"

--- a/sandbox/pnpm-lock.yaml
+++ b/sandbox/pnpm-lock.yaml
@@ -11,103 +11,104 @@ importers:
   bar:
     devDependencies:
       '@biomejs/biome':
-        specifier: 1.9.4
-        version: 1.9.4
+        specifier: https://pkg.pr.new/biomejs/biome/@biomejs/biome@1c3707dafd1337582538c336113d621558e4c176
+        version: https://pkg.pr.new/biomejs/biome/@biomejs/biome@1c3707dafd1337582538c336113d621558e4c176
 
   foo:
     devDependencies:
       '@biomejs/biome':
-        specifier: 1.9.4
-        version: 1.9.4
+        specifier: https://pkg.pr.new/biomejs/biome/@biomejs/biome@1c3707dafd1337582538c336113d621558e4c176
+        version: https://pkg.pr.new/biomejs/biome/@biomejs/biome@1c3707dafd1337582538c336113d621558e4c176
 
 packages:
 
-  '@biomejs/biome@1.9.4':
-    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+  '@biomejs/biome@https://pkg.pr.new/biomejs/biome/@biomejs/biome@1c3707dafd1337582538c336113d621558e4c176':
+    resolution: {tarball: https://pkg.pr.new/biomejs/biome/@biomejs/biome@1c3707dafd1337582538c336113d621558e4c176}
+    version: 1.9.4
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@1.9.4':
-    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+  '@biomejs/cli-darwin-arm64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-arm64@1c3707dafd1337582538c336113d621558e4c176':
+    resolution: {tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-arm64@1c3707dafd1337582538c336113d621558e4c176}
+    version: 1.9.4
     engines: {node: '>=14.21.3'}
-    cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@1.9.4':
-    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+  '@biomejs/cli-darwin-x64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-x64@1c3707dafd1337582538c336113d621558e4c176':
+    resolution: {tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-x64@1c3707dafd1337582538c336113d621558e4c176}
+    version: 1.9.4
     engines: {node: '>=14.21.3'}
-    cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
-    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+  '@biomejs/cli-linux-arm64-musl@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64-musl@1c3707dafd1337582538c336113d621558e4c176':
+    resolution: {tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64-musl@1c3707dafd1337582538c336113d621558e4c176}
+    version: 1.9.4
     engines: {node: '>=14.21.3'}
-    cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@1.9.4':
-    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+  '@biomejs/cli-linux-arm64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64@1c3707dafd1337582538c336113d621558e4c176':
+    resolution: {tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64@1c3707dafd1337582538c336113d621558e4c176}
+    version: 1.9.4
     engines: {node: '>=14.21.3'}
-    cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@1.9.4':
-    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+  '@biomejs/cli-linux-x64-musl@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64-musl@1c3707dafd1337582538c336113d621558e4c176':
+    resolution: {tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64-musl@1c3707dafd1337582538c336113d621558e4c176}
+    version: 1.9.4
     engines: {node: '>=14.21.3'}
-    cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@1.9.4':
-    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+  '@biomejs/cli-linux-x64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64@1c3707dafd1337582538c336113d621558e4c176':
+    resolution: {tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64@1c3707dafd1337582538c336113d621558e4c176}
+    version: 1.9.4
     engines: {node: '>=14.21.3'}
-    cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@1.9.4':
-    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+  '@biomejs/cli-win32-arm64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-arm64@1c3707dafd1337582538c336113d621558e4c176':
+    resolution: {tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-arm64@1c3707dafd1337582538c336113d621558e4c176}
+    version: 1.9.4
     engines: {node: '>=14.21.3'}
-    cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@1.9.4':
-    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+  '@biomejs/cli-win32-x64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-x64@1c3707dafd1337582538c336113d621558e4c176':
+    resolution: {tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-x64@1c3707dafd1337582538c336113d621558e4c176}
+    version: 1.9.4
     engines: {node: '>=14.21.3'}
-    cpu: [x64]
     os: [win32]
 
 snapshots:
 
-  '@biomejs/biome@1.9.4':
+  '@biomejs/biome@https://pkg.pr.new/biomejs/biome/@biomejs/biome@1c3707dafd1337582538c336113d621558e4c176':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 1.9.4
-      '@biomejs/cli-darwin-x64': 1.9.4
-      '@biomejs/cli-linux-arm64': 1.9.4
-      '@biomejs/cli-linux-arm64-musl': 1.9.4
-      '@biomejs/cli-linux-x64': 1.9.4
-      '@biomejs/cli-linux-x64-musl': 1.9.4
-      '@biomejs/cli-win32-arm64': 1.9.4
-      '@biomejs/cli-win32-x64': 1.9.4
+      '@biomejs/cli-darwin-arm64': https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-arm64@1c3707dafd1337582538c336113d621558e4c176
+      '@biomejs/cli-darwin-x64': https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-x64@1c3707dafd1337582538c336113d621558e4c176
+      '@biomejs/cli-linux-arm64': https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64@1c3707dafd1337582538c336113d621558e4c176
+      '@biomejs/cli-linux-arm64-musl': https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64-musl@1c3707dafd1337582538c336113d621558e4c176
+      '@biomejs/cli-linux-x64': https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64@1c3707dafd1337582538c336113d621558e4c176
+      '@biomejs/cli-linux-x64-musl': https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64-musl@1c3707dafd1337582538c336113d621558e4c176
+      '@biomejs/cli-win32-arm64': https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-arm64@1c3707dafd1337582538c336113d621558e4c176
+      '@biomejs/cli-win32-x64': https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-x64@1c3707dafd1337582538c336113d621558e4c176
 
-  '@biomejs/cli-darwin-arm64@1.9.4':
+  '@biomejs/cli-darwin-arm64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-arm64@1c3707dafd1337582538c336113d621558e4c176':
     optional: true
 
-  '@biomejs/cli-darwin-x64@1.9.4':
+  '@biomejs/cli-darwin-x64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-x64@1c3707dafd1337582538c336113d621558e4c176':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@1.9.4':
+  '@biomejs/cli-linux-arm64-musl@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64-musl@1c3707dafd1337582538c336113d621558e4c176':
     optional: true
 
-  '@biomejs/cli-linux-arm64@1.9.4':
+  '@biomejs/cli-linux-arm64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64@1c3707dafd1337582538c336113d621558e4c176':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@1.9.4':
+  '@biomejs/cli-linux-x64-musl@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64-musl@1c3707dafd1337582538c336113d621558e4c176':
     optional: true
 
-  '@biomejs/cli-linux-x64@1.9.4':
+  '@biomejs/cli-linux-x64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64@1c3707dafd1337582538c336113d621558e4c176':
     optional: true
 
-  '@biomejs/cli-win32-arm64@1.9.4':
+  '@biomejs/cli-win32-arm64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-arm64@1c3707dafd1337582538c336113d621558e4c176':
     optional: true
 
-  '@biomejs/cli-win32-x64@1.9.4':
+  '@biomejs/cli-win32-x64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-x64@1c3707dafd1337582538c336113d621558e4c176':
     optional: true

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/lsp/BiomeLspWorkspaceSettings.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/lsp/BiomeLspWorkspaceSettings.kt
@@ -1,0 +1,21 @@
+package com.github.biomejs.intellijbiome.lsp
+
+/** The settings applied to the workspace by the LSP */
+data class BiomeLspWorkspaceSettings(
+    /** Unstable features enabled */
+    var unstable: Boolean? = null,
+
+    /** Only run Biome if a `biome.json` configuration file exists. */
+    var requireConfiguration: Boolean? = null,
+
+    /** Path to the configuration file to prefer over the default `biome.json`. */
+    var configurationPath: String? = null,
+
+    /** Experimental settings */
+    var experimental: ExperimentalSettings? = null,
+) {
+    data class ExperimentalSettings(
+        /** Enable experimental symbol renaming */
+        var rename: Boolean? = null,
+    )
+}


### PR DESCRIPTION
Closes #141

I added support for `workspace/configuration` requests from the server to provide the configuration path without the `--config-path` CLI option.

See https://github.com/biomejs/biome/pull/5093 for server implementation.