### PR TITLE
ci: add management workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/01_bug-report.yaml
@@ -1,0 +1,79 @@
+name: 🐛 Bug report
+description: Report an issue with the Biome VS Code extension
+title: "🐛 "
+labels: ["Needs triage"]
+body:
+  - type: input
+    attributes:
+      label: "IDE and version"
+      description: Name of the editor and its version
+      placeholder: "WebStorm 1.86.1"
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: "Extension version"
+      description: Version of Biome JetBrains extension.
+      placeholder: "2.0.0"
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: "Biome version"
+      description: The version of Biome that the extension is using.
+      placeholder: "1.5.3"
+    validations:
+      required: true
+  - type: checkboxes
+    attributes:
+      label: "Operating system"
+      description: Check all operating systems on which you have observed the issue.
+      options:
+        - label: "Windows"
+          required: false
+        - label: "macOS"
+          required: false
+        - label: "Linux"
+          required: false
+  - type: textarea
+    attributes:
+      label: "Description"
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: "Steps to reproduce"
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: "Expected behavior"
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: "Does this issue occur when using the CLI directly?"
+      options: ["Yes", "No", "Not sure / Not applicable"]
+      default: 2
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: "Link to a minimal reproduction"
+      description: |
+        A minimal reproduction of the issue. This should be a link to a git repository.
+
+        Please be aware that **issues without a minimal reproduction are likely to be closed** without
+        further investigation. We NEED to be able to reproduce the issue in order to understand it
+        and fix it.
+
+        Please use the `npm create @biomejs/biome-reproduction` command whenever you can to bootstrap a reproduction
+        repository.

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 💡 Feature requests
+    url: https://github.com/biomejs/biome-intellij/discussions/new
+    about: Please use a new GitHub discussion to propose ideas of feature requests.
+  - name: 🗣️ Chat
+    url: https://biomejs.dev/chat
+    about: Our Discord server is active and is used for real-time discussions including contribution collaboration, questions, and more!
+  - name: 🆘 Support
+    url: https://biomejs.dev/chat
+    about: "For assistance, please use the #help channel on our Discord community."

--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -1,0 +1,22 @@
+name: Close issues
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+
+permissions:
+  issues: write
+
+jobs:
+  close-issues:
+    if: github.repository == 'biomejs/biome-intellij'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close issue without reproduction
+        uses: actions-cool/issues-helper@a610082f8ac0cf03e357eb8dd0d5e2ba075e017e # v3.6.0
+        with:
+          actions: "close-issues"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: "Needs reproduction"
+          inactive-day: 3

--- a/.github/workflows/needs-repro.yml
+++ b/.github/workflows/needs-repro.yml
@@ -1,0 +1,38 @@
+name: Needs reproduction
+
+on:
+  issues:
+    types: [ labeled ]
+
+permissions:
+  issues: write
+
+jobs:
+  reply-labeled:
+    if: github.repository == 'biomejs/biome-intellij'
+    runs-on: ubuntu-latest`
+    steps:
+      - name: Remove triaging label
+        if: contains(github.event.issue.labels.*.name, 'Bug confirmed') && contains(github.event.issue.labels.*.name, 'Needs triage')
+        uses: actions-cool/issues-helper@a610082f8ac0cf03e357eb8dd0d5e2ba075e017e # v3.6.0
+        with:
+          actions: "remove-labels"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          labels: "Needs triage"
+
+      - name: Needs reproduction
+        if: github.event.label.name == 'Needs reproduction'
+        uses: actions-cool/issues-helper@a610082f8ac0cf03e357eb8dd0d5e2ba075e017e # v3.6.0
+        with:
+          actions: "create-comment, remove-labels"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Hello @${{ github.event.issue.user.login }}, please provide a minimal reproduction. You can use one of the following options:
+
+            - Provide a link to [our playground](https://biomejs.dev/playground), if it's applicable.
+            - Provide a link to GitHub repository. To easily create a reproduction, you can use our interactive CLI via `npm create @biomejs/biome-reproduction`
+
+            Issues marked with `S-Needs repro` will be **closed** if they have **no activity within 3 days**.
+          labels: "Needs triage"


### PR DESCRIPTION
This PR adds:
- two workflows to manage the triaging and the request of reproductions. It's heavily inspired by what we have in `biomejs/biome` core;
- a default issue template inspired by what we have in `biome-vscode`, adapted to this repository