### PR TITLE
fix: do not fallback to the project root if no biome.json was found

### DIFF
--- a/sandbox/bar/biome.jsonc
+++ b/sandbox/bar/biome.jsonc
@@ -2,7 +2,10 @@
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "linter": {
     "rules": {
-      "all": true
+      "recommended": true,
+      "style": {
+        "useConst": "error"
+      }
     }
   }
 }

--- a/sandbox/bar/package.json
+++ b/sandbox/bar/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "packageManager": "pnpm@10.5.2",
   "devDependencies": {
-    "@biomejs/biome": "https://pkg.pr.new/biomejs/biome/@biomejs/biome@1c3707dafd1337582538c336113d621558e4c176"
+    "@biomejs/biome": "2.0.0-beta.1"
   },
   "scripts": {
     "check": "biome check"

--- a/sandbox/foo/biome.jsonc
+++ b/sandbox/foo/biome.jsonc
@@ -2,7 +2,7 @@
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "linter": {
     "rules": {
-      "all": true
+      "recommended": true
     }
   }
 }

--- a/sandbox/foo/package.json
+++ b/sandbox/foo/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "packageManager": "pnpm@10.5.2",
   "devDependencies": {
-    "@biomejs/biome": "https://pkg.pr.new/biomejs/biome/@biomejs/biome@1c3707dafd1337582538c336113d621558e4c176"
+    "@biomejs/biome": "2.0.0-beta.1"
   },
   "scripts": {
     "check": "biome check"

--- a/sandbox/pnpm-lock.yaml
+++ b/sandbox/pnpm-lock.yaml
@@ -11,104 +11,103 @@ importers:
   bar:
     devDependencies:
       '@biomejs/biome':
-        specifier: https://pkg.pr.new/biomejs/biome/@biomejs/biome@1c3707dafd1337582538c336113d621558e4c176
-        version: https://pkg.pr.new/biomejs/biome/@biomejs/biome@1c3707dafd1337582538c336113d621558e4c176
+        specifier: 2.0.0-beta.1
+        version: 2.0.0-beta.1
 
   foo:
     devDependencies:
       '@biomejs/biome':
-        specifier: https://pkg.pr.new/biomejs/biome/@biomejs/biome@1c3707dafd1337582538c336113d621558e4c176
-        version: https://pkg.pr.new/biomejs/biome/@biomejs/biome@1c3707dafd1337582538c336113d621558e4c176
+        specifier: 2.0.0-beta.1
+        version: 2.0.0-beta.1
 
 packages:
 
-  '@biomejs/biome@https://pkg.pr.new/biomejs/biome/@biomejs/biome@1c3707dafd1337582538c336113d621558e4c176':
-    resolution: {tarball: https://pkg.pr.new/biomejs/biome/@biomejs/biome@1c3707dafd1337582538c336113d621558e4c176}
-    version: 1.9.4
+  '@biomejs/biome@2.0.0-beta.1':
+    resolution: {integrity: sha512-MqRoy9CbTkrS45zW+S4u8p4kQUIFx0mGUWi789W1R3b1kXYIudEqsTKgXKtTGsI0kWOlvnjuKqwTrabjaGchhQ==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-arm64@1c3707dafd1337582538c336113d621558e4c176':
-    resolution: {tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-arm64@1c3707dafd1337582538c336113d621558e4c176}
-    version: 1.9.4
+  '@biomejs/cli-darwin-arm64@2.0.0-beta.1':
+    resolution: {integrity: sha512-RaGmpNLl5NFooXaoCwvgvcuU6Am/rMZ3R48pQeCVxjrCcz1BIlKLTai5UosiedazW7JbXAvgXdSNizYG7ITlAQ==}
     engines: {node: '>=14.21.3'}
+    cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-x64@1c3707dafd1337582538c336113d621558e4c176':
-    resolution: {tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-x64@1c3707dafd1337582538c336113d621558e4c176}
-    version: 1.9.4
+  '@biomejs/cli-darwin-x64@2.0.0-beta.1':
+    resolution: {integrity: sha512-sTzSshkne7HKZFNfiIhmAji7gjtCBXvkTujZELCZWIZC7oj1Tjw/gvAzbdFj2UyHd5/i90pND4ybFOLQZm9gpg==}
     engines: {node: '>=14.21.3'}
+    cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64-musl@1c3707dafd1337582538c336113d621558e4c176':
-    resolution: {tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64-musl@1c3707dafd1337582538c336113d621558e4c176}
-    version: 1.9.4
+  '@biomejs/cli-linux-arm64-musl@2.0.0-beta.1':
+    resolution: {integrity: sha512-0MPUKzz9uBBxAYSJ+OlFi4+yGwiRcZeFqq39H0MxXCQ9MMpKJFH2Ek72fw8sXwG7Prn7EsW/3u1b7najyn1XGQ==}
     engines: {node: '>=14.21.3'}
+    cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64@1c3707dafd1337582538c336113d621558e4c176':
-    resolution: {tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64@1c3707dafd1337582538c336113d621558e4c176}
-    version: 1.9.4
+  '@biomejs/cli-linux-arm64@2.0.0-beta.1':
+    resolution: {integrity: sha512-bxce2O4nooBmp20Ey0+IFIZyy/b0RVnciIQk9euCfAi9evq7SvFtMBYo3YUZej0KIvrau5H7tJk5OqmRJk2l+g==}
     engines: {node: '>=14.21.3'}
+    cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64-musl@1c3707dafd1337582538c336113d621558e4c176':
-    resolution: {tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64-musl@1c3707dafd1337582538c336113d621558e4c176}
-    version: 1.9.4
+  '@biomejs/cli-linux-x64-musl@2.0.0-beta.1':
+    resolution: {integrity: sha512-dFvisnP1hFpVILNw0PZfs8piBwe8+aykO04Tb/4AJDVVzKkGgJfwSefwo4jqzO/Wk/Zruvhcp1nKbjgRXM+vDg==}
     engines: {node: '>=14.21.3'}
+    cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64@1c3707dafd1337582538c336113d621558e4c176':
-    resolution: {tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64@1c3707dafd1337582538c336113d621558e4c176}
-    version: 1.9.4
+  '@biomejs/cli-linux-x64@2.0.0-beta.1':
+    resolution: {integrity: sha512-6P/AtJv4hOH8mu8ez0c4UInUpiet9NEoF25+O7OPyb4w6ZHJMp2qzvayJS7TKrTQzE5KUvSiNsACGRz34DzUkg==}
     engines: {node: '>=14.21.3'}
+    cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-arm64@1c3707dafd1337582538c336113d621558e4c176':
-    resolution: {tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-arm64@1c3707dafd1337582538c336113d621558e4c176}
-    version: 1.9.4
+  '@biomejs/cli-win32-arm64@2.0.0-beta.1':
+    resolution: {integrity: sha512-0C9YSqWHf2cJGnjKDbLi49xv6H9IfqbDsFav7X557PqwY64O6IKWqcmZzi/PkDFHjQM9opU6uhKapeGKGDxziQ==}
     engines: {node: '>=14.21.3'}
+    cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-x64@1c3707dafd1337582538c336113d621558e4c176':
-    resolution: {tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-x64@1c3707dafd1337582538c336113d621558e4c176}
-    version: 1.9.4
+  '@biomejs/cli-win32-x64@2.0.0-beta.1':
+    resolution: {integrity: sha512-o8W6+DX0YRjt1kS8Y3ismq6EkjwiVDv7X0TEpfnFywoVG8HoJ7G7/m9r8LM1yE46WI3maPH2A0MoVpQ1ZNG++A==}
     engines: {node: '>=14.21.3'}
+    cpu: [x64]
     os: [win32]
 
 snapshots:
 
-  '@biomejs/biome@https://pkg.pr.new/biomejs/biome/@biomejs/biome@1c3707dafd1337582538c336113d621558e4c176':
+  '@biomejs/biome@2.0.0-beta.1':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-arm64@1c3707dafd1337582538c336113d621558e4c176
-      '@biomejs/cli-darwin-x64': https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-x64@1c3707dafd1337582538c336113d621558e4c176
-      '@biomejs/cli-linux-arm64': https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64@1c3707dafd1337582538c336113d621558e4c176
-      '@biomejs/cli-linux-arm64-musl': https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64-musl@1c3707dafd1337582538c336113d621558e4c176
-      '@biomejs/cli-linux-x64': https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64@1c3707dafd1337582538c336113d621558e4c176
-      '@biomejs/cli-linux-x64-musl': https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64-musl@1c3707dafd1337582538c336113d621558e4c176
-      '@biomejs/cli-win32-arm64': https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-arm64@1c3707dafd1337582538c336113d621558e4c176
-      '@biomejs/cli-win32-x64': https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-x64@1c3707dafd1337582538c336113d621558e4c176
+      '@biomejs/cli-darwin-arm64': 2.0.0-beta.1
+      '@biomejs/cli-darwin-x64': 2.0.0-beta.1
+      '@biomejs/cli-linux-arm64': 2.0.0-beta.1
+      '@biomejs/cli-linux-arm64-musl': 2.0.0-beta.1
+      '@biomejs/cli-linux-x64': 2.0.0-beta.1
+      '@biomejs/cli-linux-x64-musl': 2.0.0-beta.1
+      '@biomejs/cli-win32-arm64': 2.0.0-beta.1
+      '@biomejs/cli-win32-x64': 2.0.0-beta.1
 
-  '@biomejs/cli-darwin-arm64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-arm64@1c3707dafd1337582538c336113d621558e4c176':
+  '@biomejs/cli-darwin-arm64@2.0.0-beta.1':
     optional: true
 
-  '@biomejs/cli-darwin-x64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-x64@1c3707dafd1337582538c336113d621558e4c176':
+  '@biomejs/cli-darwin-x64@2.0.0-beta.1':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64-musl@1c3707dafd1337582538c336113d621558e4c176':
+  '@biomejs/cli-linux-arm64-musl@2.0.0-beta.1':
     optional: true
 
-  '@biomejs/cli-linux-arm64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64@1c3707dafd1337582538c336113d621558e4c176':
+  '@biomejs/cli-linux-arm64@2.0.0-beta.1':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64-musl@1c3707dafd1337582538c336113d621558e4c176':
+  '@biomejs/cli-linux-x64-musl@2.0.0-beta.1':
     optional: true
 
-  '@biomejs/cli-linux-x64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64@1c3707dafd1337582538c336113d621558e4c176':
+  '@biomejs/cli-linux-x64@2.0.0-beta.1':
     optional: true
 
-  '@biomejs/cli-win32-arm64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-arm64@1c3707dafd1337582538c336113d621558e4c176':
+  '@biomejs/cli-win32-arm64@2.0.0-beta.1':
     optional: true
 
-  '@biomejs/cli-win32-x64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-x64@1c3707dafd1337582538c336113d621558e4c176':
+  '@biomejs/cli-win32-x64@2.0.0-beta.1':
     optional: true

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/lsp/BiomeLspServerSupportProvider.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/lsp/BiomeLspServerSupportProvider.kt
@@ -27,9 +27,9 @@ import org.eclipse.lsp4j.ConfigurationItem
         serverStarter: LspServerSupportProvider.LspServerStarter,
     ) {
         // Finds the root directory of a Biome workspace. It's typically the parent directory of `biome.json`.
-        // If no `biome.json` file found, fallbacks to the project root directory.
+        // If no `biome.json` file found, nothing to do.
         val projectRootDir = project.guessProjectDir() ?: return
-        val root = file.findNearestBiomeConfig(projectRootDir)?.parent ?: projectRootDir
+        val root = file.findNearestBiomeConfig(projectRootDir)?.parent ?: return
 
         val biome = BiomePackage(project)
         val configPath = biome.configPath()


### PR DESCRIPTION
Fixes #158 

Previously, the root directory for the LSP server was falled back to the project root when no biome.json(c) is found. However, that causes duplicated instances for a file, after opened a file **outside** Biome-installed directory.

<img width="358" alt="image" src="https://github.com/user-attachments/assets/8e5a146b-0300-41eb-bdad-4704e5d28787" />

I removed the fallback and now nothing will happen if no biome.json(c) is found.