### PR TITLE
ci: fix invalid runner name

### DIFF
--- a/.github/workflows/needs-repro.yml
+++ b/.github/workflows/needs-repro.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   reply-labeled:
     if: github.repository == 'biomejs/biome-intellij'
-    runs-on: ubuntu-latest`
+    runs-on: ubuntu-latest
     steps:
       - name: Remove triaging label
         if: contains(github.event.issue.labels.*.name, 'Bug confirmed') && contains(github.event.issue.labels.*.name, 'Needs triage')


### PR DESCRIPTION
Removed an unnecessary char that causes missing runner issues (e.g. https://github.com/biomejs/biome-intellij/actions/runs/14096435815).