### PR TITLE
fix: regression where the plugin couldn't find biome.json at the project root

### DIFF
--- a/src/main/kotlin/com/github/biomejs/intellijbiome/extensions/FileExt.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/extensions/FileExt.kt
@@ -1,5 +1,6 @@
 package com.github.biomejs.intellijbiome.extensions
 
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import java.io.BufferedReader
 import java.io.File
@@ -20,7 +21,7 @@ private fun VirtualFile.findNearestFile(
     root: VirtualFile? = null,
 ): VirtualFile? {
     var cur = this.parent
-    while (cur != null && cur.path != root?.path) {
+    while (cur != null && VfsUtil.isUnder(cur, mutableSetOf(root))) {
         val f = cur.children.find(predicate)
         if (f != null) {
             return f


### PR DESCRIPTION
Fixes #165 

The extension method `VirtualFile.findNearestFile` limits the topmost directory to the specified directory, but not allowed the directory itself. It caused that the plugin can't find biome.json at the project root directory.

Manually tested to open a project with only one biome.json at the root, and a monorepo project with biome.json files for each package.