### PR TITLE
fix: use source.fixAll.biome instead of quickfix.biome

### DIFF
--- a/src/main/kotlin/com/github/biomejs/intellijbiome/services/BiomeServerService.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/services/BiomeServerService.kt
@@ -71,7 +71,7 @@ class BiomeServerService(private val project: Project) {
                     getLsp4jRange(document, 0, document.textLength),
                     CodeActionContext().apply {
                         diagnostics = emptyList()
-                        only = listOf("quickfix.biome")
+                        only = listOf("source.fixAll.biome")
                         triggerKind = CodeActionTriggerKind.Automatic
                     })
 


### PR DESCRIPTION
Fixes #185 
Fixes #188 (possibly)
Fixes #143 (possibly)

It was a very easy fix 😅 

This plugin used `quickfix.biome` to pull code actions from the server, but with it the server responses code actions **for each diagnostic**. This means the fixes can conflict with others, and break the code in the editor. Instead, `source.fixAll.biome` returns only one code action which resolves all diagnostics in the file.