### PR TITLE
ci: use AMD64 runner for creating GH releases

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -61,7 +61,7 @@ jobs:
   publish-github-release:
     name: Publish to GitHub Releases
     needs: [ build ]
-    runs-on: depot-ubuntu-24.04-arm-16
+    runs-on: depot-ubuntu-24.04
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
orhun/git-cliff-action, used in the workflow, only supports AMD64 environments. The current workflow used an Arm64 runner on Depot and caused a failure.