### PR TITLE
feat: add syntax highlighting for GritQL

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,6 +94,12 @@ tasks {
   test {
     useJUnitPlatform()
   }
+
+  prepareSandbox {
+    from(layout.projectDirectory.dir("grit-vscode")) {
+      into(pluginName.map { "$it/grit-vscode" })
+    }
+  }
 }
 
 intellijPlatformTesting {

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ platformVersion = 2024.3.6
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP
 platformPlugins =
 # Example: platformBundledPlugins = com.intellij.java
-platformBundledPlugins = JavaScript
+platformBundledPlugins = JavaScript, org.jetbrains.plugins.textmate
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 8.14.2

--- a/grit-vscode/README.md
+++ b/grit-vscode/README.md
@@ -1,0 +1,10 @@
+# grit-vscode
+
+This directory contains some files extracted from the GritQL extension for VS Code.
+
+## How to update
+
+```shell
+curl -sSL https://marketplace.visualstudio.com/_apis/public/gallery/publishers/Grit/vsextensions/grit-vscode/0.3.10/vspackage \
+  | tar -xzf - 'extension/*.json' 'extension/dist/*.json' 'extension/syntaxes/*.json'
+```

--- a/grit-vscode/extension/dist/grit.tmLanguage.json
+++ b/grit-vscode/extension/dist/grit.tmLanguage.json
@@ -1,0 +1,401 @@
+{
+    "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+    "name": "grit",
+    "patterns": [
+        {
+            "include": "#info"
+        },
+        {
+            "include": "#entity.definition"
+        },
+        {
+            "include": "#entity.foreign"
+        },
+        {
+            "include": "#expression"
+        }
+    ],
+    "repository": {
+        "comment-single-line": {
+            "patterns": [
+                {
+                    "name": "comment.grit",
+                    "match": "//.+$"
+                }
+            ]
+        },
+        "comment-expression": {
+            "begin": "\\/\\*",
+            "end": "\\*\\/",
+            "name": "comment.grit"
+        },
+        "paren-expression": {
+            "begin": "\\(",
+            "end": "\\)",
+            "beginCaptures": {
+                "0": { "name": "punctuation.paren.open.grit" }
+            },
+            "endCaptures": {
+                "0": { "name": "punctuation.paren.close.grit" }
+            },
+            "name": "expression.group.grit",
+            "patterns": [{ "include": "#expression" }]
+        },
+        "curlybrace-expression": {
+            "begin": "{",
+            "end": "}",
+            "beginCaptures": {
+                "0": { "name": "punctuation.curlybrace.open.grit" }
+            },
+            "endCaptures": {
+                "0": { "name": "punctuation.curlybrace.close.grit" }
+            },
+            "name": "expression.group.grit",
+            "patterns": [{ "include": "#expression" }]
+        },
+        "squarebracket-expression": {
+            "begin": "\\[",
+            "end": "\\]",
+            "beginCaptures": {
+                "0": { "name": "punctuation.squarebracket.open.grit" }
+            },
+            "endCaptures": {
+                "0": { "name": "punctuation.squarebracket.close.grit" }
+            },
+            "name": "expression.group.grit",
+            "patterns": [{ "include": "#expression" }]
+        },
+        "info": {
+            "patterns": [
+                {
+                    "include": "#meta.engine"
+                },
+                {
+                    "include": "#meta.language"
+                }
+            ]
+        },
+        "meta.engine": {
+            "name": "meta.engine.grit",
+            "begin": "(engine) (marzano)\\(([\\d.]+)\\)",
+            "beginCaptures": {
+                "1": {
+                    "name": "keyword.control.grit"
+                },
+                "2": {
+                    "name": "constant.language.grit"
+                },
+                "3": {
+                    "name": "constant.numeric.grit"
+                }
+            },
+            "end": "(\\n)",
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.terminator.grit"
+                }
+            }
+        },
+        "meta.language": {
+            "name": "meta.language.grit",
+            "begin": "(language) (\\w+)(?:\\(([\\w]+)\\))?",
+            "beginCaptures": {
+                "1": {
+                    "name": "keyword.control.grit"
+                },
+                "2": {
+                    "name": "constant.language.grit"
+                },
+                "3": {
+                    "name": "constant.language.grit"
+                }
+            },
+            "end": "(\\n)",
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.terminator.grit"
+                }
+            }
+        },
+        "entity.definition": {
+            "name": "meta.definition.grit",
+            "begin": "(private )?(pattern|function|predicate) (\\w+)\\((.*)\\) \\{",
+            "beginCaptures": {
+                "1": {
+                    "name": "constant.language.grit"
+                },
+                "2": {
+                    "name": "keyword.control.grit"
+                },
+                "3": {
+                    "name": "entity.name.function.grit"
+                },
+                "4": {
+                    "name": "variable.parameter.function.grit"
+                }
+            },
+            "patterns": [{ "include": "#expression" }],
+            "end": "\\}(\\n)",
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.terminator.grit"
+                }
+            }
+        },
+        "entity.foreign": {
+            "name": "meta.foreign.grit",
+            "begin": "(private )?(function) (\\w+)\\((.*)\\)(?: (js|html|css|json|java|csharp|markdown|python|go|rust|ruby|sol|solidity|hcl|yaml)) \\{",
+            "beginCaptures": {
+                "1": {
+                    "name": "constant.language.grit"
+                },
+                "2": {
+                    "name": "keyword.control.grit"
+                },
+                "3": {
+                    "name": "entity.name.function.grit"
+                },
+                "4": {
+                    "name": "variable.parameter.function.grit"
+                },
+                "5": {
+                    "name": "meta.language.grit"
+                }
+            },
+            "patterns": [
+                {
+                    "name": "nested.curly.grit",
+                    "begin": "\\{",
+                    "end": "\\}",
+                    "applyEndPatternLast": 1,
+                    "patterns": [
+                        {
+                            "include": "#variables"
+                        },
+                        {
+                            "match": "(?:[^{}])*"
+                        },
+                        {
+                            "include": "#nested.curly.grit"
+                        }
+                    ]
+                },
+                {
+                    "include": "#variables"
+                }
+            ],
+            "end": "\\}(\\n)",
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.terminator.grit"
+                }
+            }
+        },
+        "expression": {
+            "patterns": [
+                {
+                    "include": "#comment-single-line"
+                },
+                {
+                    "include": "#comment-expression"
+                },
+                {
+                    "include": "#paren-expression"
+                },
+                {
+                    "include": "#curlybrace-expression"
+                },
+                {
+                    "include": "#squarebracket-expression"
+                },
+                {
+                    "include": "#keywords"
+                },
+                {
+                    "include": "#grit-snippet"
+                },
+                {
+                    "include": "#string-double-quoted"
+                },
+                {
+                    "include": "#constants"
+                },
+                {
+                    "include": "#operators"
+                },
+                {
+                    "include": "#variables"
+                }
+            ]
+        },
+        "keywords": {
+            "patterns": [
+                {
+                    "name": "keyword.control.grit",
+                    "match": "\\b(if|then|else|as|any|some|contains|before|after|semantic|until|where|maybe|not|or|and|within|bubble|import|private|sequential|limit)\\b"
+                }
+            ]
+        },
+        "grit-snippet": {
+            "patterns": [
+                {
+                    "include": "#grit-snippet-tick"
+                },
+                {
+                    "include": "#grit-snippet-lang"
+                }
+            ]
+        },
+        "grit-snippet-lang": {
+            "begin": "((js|html|css|json|java|csharp|markdown|python|go|rust|ruby|sol|solidity|hcl|yaml)\")",
+            "beginCaptures": {
+                "0": {
+                    "name": "markup.quote.literal.begin.grit"
+                },
+                "2": {
+                    "name": "markup.quote.literal.language.grit"
+                }
+            },
+            "end": "(\")",
+            "endCaptures": {
+                "0": {
+                    "name": "markup.quote.literal.end.grit"
+                }
+            },
+            "name": "string.interpolated.grit-snippet",
+            "patterns": [
+                {
+                    "include": "#interpolated-variables"
+                }
+            ]
+        },
+        "grit-snippet-tick": {
+            "begin": "(`)",
+            "beginCaptures": {
+                "0": {
+                    "name": "markup.quote.literal.begin.grit"
+                }
+            },
+            "end": "(`)",
+            "endCaptures": {
+                "0": {
+                    "name": "markup.quote.literal.end.grit"
+                }
+            },
+            "name": "string.interpolated.grit-snippet",
+            "patterns": [
+                {
+                    "include": "#interpolated-variables"
+                }
+            ]
+        },
+        "string-double-quoted": {
+            "begin": "(\")",
+            "beginCaptures": {
+                "0": {
+                    "name": "markup.quote.string.begin.grit"
+                }
+            },
+            "end": "(\")",
+            "endCaptures": {
+                "0": {
+                    "name": "markup.quote.string.end.grit"
+                }
+            },
+            "name": "string.double-quoted.grit",
+            "patterns": [
+                {
+                    "include": "#interpolated-variables"
+                }
+            ]
+        },
+        "interpolated-variables": {
+            "patterns": [
+                {
+                    "match": "\\$\\b[a-zA-Z][a-zA-Z0-9_]*\\b",
+                    "name": "variable.interpolated.grit"
+                },
+                {
+                    "match": "\\$\\b_[a-zA-Z0-9_]*\\b",
+                    "name": "variable.special.interpolated.grit"
+                },
+                {
+                    "match": "\\$\\.\\.\\.",
+                    "name": "variable.special.interpolated.grit"
+                },
+                {
+                    "begin": "(\\$\\[)",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "variable.interpolated.begin.grit"
+                        }
+                    },
+                    "end": "(\\])",
+                    "endCaptures": {
+                        "0": {
+                            "name": "variable.interpolated.end.grit"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#variables"
+                        }
+                    ]
+                }
+            ]
+        },
+        "variables": {
+            "patterns": [
+                {
+                    "match": "\\b(program)\\b",
+                    "name": "variable.special.grit"
+                },
+                {
+                    "match": "\\$\\b[a-z][a-zA-Z0-9_]*\\b",
+                    "name": "variable.startsign.grit"
+                },
+                {
+                    "match": "\\b[a-zA-Z][a-zA-Z0-9_]*\\b",
+                    "name": "variable.grit"
+                },
+                {
+                    "match": "\\$?\\b_[a-zA-Z0-9_]*\\b",
+                    "name": "variable.special.grit"
+                },
+                {
+                    "match": "\\$?\\.\\.\\.",
+                    "name": "variable.special.grit"
+                }
+            ]
+        },
+        "constants": {
+            "patterns": [
+                {
+                    "match": "([0-9]+\\.[0-9]+)",
+                    "name": "constant.numeric.decimal.grit"
+                },
+                {
+                    "match": "([0-9]+)",
+                    "name": "constant.numeric.integer.grit"
+                },
+                {
+                    "match": "(true|false)",
+                    "name": "constant.language.grit"
+                },
+                {
+                    "match": "(Top|Bottom)",
+                    "name": "constant.language.grit"
+                }
+            ]
+        },
+        "operators": {
+            "patterns": [
+                {
+                    "match": "(<::|<:|&&|&|!|==|!=|=>|=:|=|/|%|\\|\\||\\+|\\*|<|>|\\|)",
+                    "name": "keyword.operator.grit"
+                }
+            ]
+        }
+    },
+    "scopeName": "source.grit"
+}

--- a/grit-vscode/extension/language-configuration.json
+++ b/grit-vscode/extension/language-configuration.json
@@ -1,0 +1,30 @@
+{
+  "comments": {
+    // symbol used for single line comment. Remove this entry if your language does not support line comments
+    "lineComment": "//",
+    // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
+    "blockComment": ["/*", "*/"]
+  },
+  // symbols used as brackets
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  // symbols that are auto closed when typing
+  "autoClosingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""],
+    ["'", "'"]
+  ],
+  // symbols that can be used to surround a selection
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""],
+    ["'", "'"]
+  ]
+}

--- a/grit-vscode/extension/package.json
+++ b/grit-vscode/extension/package.json
@@ -1,0 +1,200 @@
+{
+  "name": "grit-vscode",
+  "displayName": "Grit",
+  "description": "Grit is a code transformation tool.",
+  "version": "0.3.10",
+  "publisher": "grit",
+  "engines": {
+    "vscode": "^1.50.0"
+  },
+  "preview": true,
+  "license": "See license in LICENSE.md",
+  "homepage": "https://grit.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/getgrit/vscode.git"
+  },
+  "icon": "assets/grit_logo.png",
+  "categories": [
+    "Programming Languages",
+    "Formatters",
+    "Linters"
+  ],
+  "keywords": [
+    "grit",
+    "transformation",
+    "codemods",
+    "migration",
+    "javascript"
+  ],
+  "activationEvents": [
+    "onCommand:grit.applyNamedPattern",
+    "onLanguage:plaintext",
+    "onLanguage:javascript",
+    "onView:semanticSearch",
+    "onLanguage:rust",
+    "onLanguage:typescript",
+    "onLanguage:typescriptreact",
+    "onLanguage:javascriptreact",
+    "onLanguage:python",
+    "onLanguage:json",
+    "onLanguage:jsonc",
+    "onLanguage:markdown",
+    "onLanguage:yaml",
+    "onLanguage:java",
+    "onLanguage:solidity",
+    "onLanguage:hcl",
+    "onLanguage:terraform",
+    "onLanguage:sql"
+  ],
+  "main": "./dist/extension.js",
+  "contributes": {
+    "languages": [
+      {
+        "id": "grit",
+        "aliases": [
+          "grit"
+        ],
+        "extensions": [
+          ".grit",
+          ".unhack"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "scopeName": "markdown.grit.codeblock",
+        "path": "./syntaxes/grit.codeblock.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.grit": "grit"
+        }
+      },
+      {
+        "language": "grit",
+        "scopeName": "source.grit",
+        "path": "./dist/grit.tmLanguage.json"
+      }
+    ],
+    "commands": [
+      {
+        "command": "grit.openPatternSelector",
+        "title": "Apply Pattern",
+        "category": "Grit"
+      },
+      {
+        "command": "grit.showDebugInfo",
+        "title": "Show Debug Info",
+        "category": "Grit"
+      },
+      {
+        "command": "grit.fixFile",
+        "title": "Fix File",
+        "category": "Grit"
+      },
+      {
+        "command": "grit.openSearch",
+        "title": "Search with GritQL",
+        "category": "Grit"
+      },
+      {
+        "command": "grit.restartServer",
+        "title": "Restart Language Server",
+        "category": "Grit"
+      }
+    ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "grit.openPatternSelector",
+          "when": "editorLangId == javascript || editorLangId == rust || editorLangId == typescript || editorLangId == typescriptreact || editorLangId == javascriptreact || editorLangId == python || editorLangId == json || editorLangId == jsonc || editorLangId == markdown || editorLangId == yaml || editorLangId == solidity || editorLangId == hcl || editorLangId == terraform || editorLangId == sql",
+          "group": "grit"
+        },
+        {
+          "command": "grit.fixFile",
+          "when": "editorLangId == javascript || editorLangId == rust || editorLangId == typescript || editorLangId == typescriptreact || editorLangId == javascriptreact || editorLangId == python || editorLangId == json || editorLangId == jsonc || editorLangId == markdown || editorLangId == yaml || editorLangId == solidity || editorLangId == hcl || editorLangId == terraform || editorLangId == sql",
+          "group": "grit"
+        },
+        {
+          "command": "grit.showDebugInfo",
+          "group": "grit"
+        }
+      ],
+      "view/item/context": []
+    },
+    "configuration": {
+      "type": "object",
+      "title": "LSP configuration",
+      "properties": {
+        "grit.authoring.test_matches": {
+          "scope": "application",
+          "type": "boolean",
+          "default": false,
+          "description": "Show live highlights for matches in Grit markdown files"
+        },
+        "grit.lsp.status": {
+          "scope": "application",
+          "type": "boolean",
+          "default": false,
+          "description": "Show language server status in the status bar"
+        },
+        "grit.lsp.binary": {
+          "scope": "window",
+          "type": "string",
+          "default": "grit",
+          "description": "The path to the grit binary hosting the language server."
+        },
+        "grit.trace.server": {
+          "scope": "window",
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "verbose",
+          "description": "Traces the communication between VSCode and the language server."
+        }
+      }
+    },
+    "viewsContainers": {},
+    "views": {}
+  },
+  "scripts": {
+    "vscode:prepublish": "yarn run build",
+    "build:typecheck": "tsc -p tsconfig.json --noEmit",
+    "build:package": "rm -rf dist && esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --minify",
+    "build": "yarn run build:typecheck && yarn run build:package",
+    "dev": "tsc -watch --preserveWatchOutput -p ./",
+    "lint": "eslint src --ext ts",
+    "package": "vsce package",
+    "postbuild": "cp ../../packages/universal/dist/ast/grit.tmLanguage.json ./dist/grit.tmLanguage.json",
+    "release": "vsce publish --yarn",
+    "load": "vsce package && code --install-extension grit-vscode-0.2.0.vsix",
+    "test": "yarn node node_modules/.bin/jest --runInBand --forceExit",
+    "test:ci": "yarn test"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.42",
+    "@types/vscode": "^1.50.0",
+    "@vscode/vsce": "^2.15.0",
+    "esbuild": "^0.16.9",
+    "@getgrit/sdk": "*",
+    "jest": "^29.3.1"
+  },
+  "dependencies": {
+    "@vscode/webview-ui-toolkit": "^1.2.0",
+    "typescript": "^5.0.3",
+    "vscode-languageclient": "^8.0.2",
+    "vscode-languageserver-protocol": "^3.17.2",
+    "@getgrit/universal": "*",
+    "@getgrit/api": "*",
+    "lodash": "^4.17.21"
+  },
+  "__metadata": {
+    "publisherDisplayName": "Grit"
+  }
+}

--- a/grit-vscode/extension/syntaxes/grit.codeblock.json
+++ b/grit-vscode/extension/syntaxes/grit.codeblock.json
@@ -1,0 +1,45 @@
+{
+  "fileTypes": [],
+  "injectionSelector": "L:text.html.markdown",
+  "patterns": [
+    {
+      "include": "#grit-code-block"
+    }
+  ],
+  "repository": {
+    "grit-code-block": {
+      "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(grit)(\\s+[^`~]*)?$)",
+      "name": "markup.fenced_code.block.markdown",
+      "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+      "beginCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        },
+        "5": {
+          "name": "fenced_code.block.language"
+        },
+        "6": {
+          "name": "fenced_code.block.language.attributes"
+        }
+      },
+      "endCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        }
+      },
+      "patterns": [
+        {
+          "begin": "(^|\\G)(\\s*)(.*)",
+          "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+          "contentName": "meta.embedded.block.grit",
+          "patterns": [
+            {
+              "include": "source.grit"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "scopeName": "markdown.grit.codeblock"
+}

--- a/sandbox/foo/example.grit
+++ b/sandbox/foo/example.grit
@@ -1,0 +1,12 @@
+`namedColors = { $colors }` where {
+	$keys = "",
+	$values = [],
+	$colors <: some bubble($keys, $values) `$name: $color` where {
+		// Push the name onto the string
+		$keys += $name,
+		// Push the values onto the list
+		$values += `$color`
+	},
+	// Join the values together to make a string
+	$new_colors = join(list=$values, separator=", ")
+} => `$keys = [ $new_colors ]`

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeSettingsState.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeSettingsState.kt
@@ -25,7 +25,7 @@ class BiomeSettingsState : BaseState() {
 
     companion object {
         val DEFAULT_EXTENSION_LIST = listOf(
-            ".astro", ".css", ".gql", ".graphql", ".js", ".mjs", ".cjs", ".jsx",
+            ".astro", ".css", ".gql", ".graphql", ".grit", ".js", ".mjs", ".cjs", ".jsx",
             ".json", ".jsonc", ".svelte", ".html", ".ts", ".mts", ".cts", ".tsx", ".vue"
         )
     }

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/textmate/GritTextMateBundleProvider.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/textmate/GritTextMateBundleProvider.kt
@@ -1,0 +1,11 @@
+package com.github.biomejs.intellijbiome.textmate
+
+import com.intellij.openapi.application.PluginPathManager
+import org.jetbrains.plugins.textmate.api.TextMateBundleProvider
+
+class GritTextMateBundleProvider : TextMateBundleProvider {
+    override fun getBundles(): List<TextMateBundleProvider.PluginBundle> =
+        PluginPathManager.getPluginResource(javaClass, "grit-vscode/extension")
+            ?.let { listOf(TextMateBundleProvider.PluginBundle("grit", it.toPath())) }
+            ?: emptyList()
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -41,6 +41,7 @@
 
   <depends>com.intellij.modules.platform</depends>
   <depends>com.intellij.modules.ultimate</depends>
+  <depends>org.jetbrains.plugins.textmate</depends>
   <depends>JavaScript</depends>
 
   <resource-bundle>messages.BiomeBundle</resource-bundle>
@@ -64,6 +65,7 @@
                   implementation="com.github.biomejs.intellijbiome.actions.BiomeCheckOnSaveAction"
                   order="first, before FormatOnSaveAction"/>
     />
+    <textmate.bundleProvider implementation="com.github.biomejs.intellijbiome.textmate.GritTextMateBundleProvider" />
   </extensions>
   <actions>
     <action


### PR DESCRIPTION
https://github.com/biomejs/biome-vscode/issues/686 but for IntelliJ

Added syntax highlighting support for GritQL.

IntelliJ IDEs support [TextMate bundles](https://www.jetbrains.com/help/idea/textmate-bundles.html) and plugins can provide bundles automatically. By using this, we can rely on the syntax included in [the official extension](https://marketplace.visualstudio.com/items?itemName=Grit.grit-vscode), instead of having our own PSI implementation.

I also added `.grit` to the default extensions list that Biome supports format/lint/assist.