### PR TITLE
fix: revert "perf: use DocumentUtil.executeInBulk for formatting"

### DIFF
--- a/src/main/kotlin/com/github/biomejs/intellijbiome/services/BiomeServerService.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/services/BiomeServerService.kt
@@ -19,7 +19,6 @@ import com.intellij.platform.lsp.api.LspServerManager
 import com.intellij.platform.lsp.api.customization.LspIntentionAction
 import com.intellij.platform.lsp.util.getLsp4jRange
 import com.intellij.platform.lsp.util.getRangeInDocument
-import com.intellij.util.DocumentUtil
 import com.intellij.util.LineSeparator
 import org.eclipse.lsp4j.*
 import java.util.*
@@ -54,6 +53,10 @@ class BiomeServerService(private val project: Project) {
 
     fun restartBiomeServer() {
         LspServerManager.getInstance(project).stopAndRestartIfNeeded(BiomeLspServerSupportProvider::class.java)
+    }
+
+    fun stopBiomeServer() {
+        LspServerManager.getInstance(project).stopServers(BiomeLspServerSupportProvider::class.java)
     }
 
     suspend fun executeFeatures(document: Document,
@@ -162,7 +165,7 @@ class BiomeServerService(private val project: Project) {
             }
 
             WriteCommandAction.runWriteCommandAction(project, commandName, groupId, {
-                DocumentUtil.executeInBulk(document, formattingAction)
+                formattingAction.run()
             })
         }
     }


### PR DESCRIPTION
Reverts biomejs/biome-intellij#184
Fixes #200 

We have received some reports that an error occurs when formatting on save, and I also experienced this in a specific project:

```
Current operation is not permitted in bulk mode, see Document.isInBulkUpdate() javadoc
```

Reverting the changes for now.