### PR TITLE
fix: support deserialising `extends` as a list

### DIFF
--- a/src/main/kotlin/com/github/biomejs/intellijbiome/BiomeConfig.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/BiomeConfig.kt
@@ -3,15 +3,22 @@ package com.github.biomejs.intellijbiome
 import com.intellij.openapi.vfs.VirtualFile
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.*
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonTransformingSerializer
 import kotlinx.serialization.json.decodeFromStream
 
 @Serializable
 data class BiomeConfig(
     val root: Boolean? = null,
-    val extends: String? = null,
+
+    @Serializable(with = ExtendsSerializer::class)
+    val extends: List<String>? = null,
 ) {
-    fun isRootConfig() = root != false && extends != "//"
+    fun isRootConfig() =
+        root != false && extends?.contains("//") != true
 
     companion object {
         @OptIn(ExperimentalSerializationApi::class)
@@ -28,5 +35,10 @@ data class BiomeConfig(
                 null
             }
         }
+    }
+
+    object ExtendsSerializer : JsonTransformingSerializer<List<String>>(ListSerializer(String.serializer())) {
+        override fun transformDeserialize(element: JsonElement): JsonElement =
+            element as? JsonArray ?: JsonArray(listOf(element))
     }
 }


### PR DESCRIPTION
Fixes #213 

The `extends` option can be a string or a list of string. The `BiomeConfig` dat class did not support a string list, so the plugin couldn't resolve the configuration correctly.