### PR TITLE
feat: remove the version indicator on Actions on Save page

### DIFF
--- a/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeActionInfo.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeActionInfo.kt
@@ -2,30 +2,13 @@ package com.github.biomejs.intellijbiome.settings
 
 import com.github.biomejs.intellijbiome.BiomeBundle
 import com.intellij.ide.actionsOnSave.ActionOnSaveComment
-import com.intellij.openapi.util.text.StringUtil
 
 class ActionInfo {
     companion object {
-        fun defaultComment(
-            version: String?,
-            isActionOnSaveEnabled: Boolean
-        ): ActionOnSaveComment? {
-            if (version == null) {
-                val message = BiomeBundle.message("biome.run.on.save.package.not.specified.warning")
-                return if (isActionOnSaveEnabled) ActionOnSaveComment.warning(message) else ActionOnSaveComment.info(
-                    message
-                )
-            }
-
+        fun disabled(): ActionOnSaveComment {
             return ActionOnSaveComment.info(
-                BiomeBundle.message(
-                    "biome.run.on.save.version.and.files.pattern",
-                    shorten(version, 15),
-                )
+                BiomeBundle.message("biome.run.on.save.disabled")
             )
         }
-
-        fun shorten(s: String,
-            max: Int) = StringUtil.shortenTextWithEllipsis(s, max, 0, true)
     }
 }

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeOnSaveApplySafeFixesActionInfo.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeOnSaveApplySafeFixesActionInfo.kt
@@ -1,11 +1,9 @@
 package com.github.biomejs.intellijbiome.settings
 
 import com.github.biomejs.intellijbiome.BiomeBundle
-import com.github.biomejs.intellijbiome.BiomePackage
 import com.intellij.ide.actionsOnSave.ActionOnSaveBackedByOwnConfigurable
 import com.intellij.ide.actionsOnSave.ActionOnSaveComment
 import com.intellij.ide.actionsOnSave.ActionOnSaveContext
-import com.intellij.platform.ide.progress.runWithModalProgressBlocking
 
 class BiomeOnSaveApplySafeFixesActionInfo(actionOnSaveContext: ActionOnSaveContext) :
     ActionOnSaveBackedByOwnConfigurable<BiomeConfigurable>(actionOnSaveContext,
@@ -31,23 +29,21 @@ class BiomeOnSaveApplySafeFixesActionInfo(actionOnSaveContext: ActionOnSaveConte
         configurable.runSafeFixesOnSaveCheckBox.isSelected = enabled
     }
 
-    override fun getCommentAccordingToUiState(configurable: BiomeConfigurable): ActionOnSaveComment? {
-        return comment()
-    }
-
-    override fun getCommentAccordingToStoredState(): ActionOnSaveComment? {
-        return comment()
-    }
-
     override fun getActionLinks() = listOf(createGoToPageInSettingsLink(BiomeConfigurable.CONFIGURABLE_ID))
 
-    private fun comment(): ActionOnSaveComment? {
-        if (!isSaveActionApplicable) return ActionOnSaveComment.info(BiomeBundle.message("biome.on.save.comment.disabled"))
-
-        val biomePackage = BiomePackage(project)
-        val version = runWithModalProgressBlocking(project, BiomeBundle.message("biome.version")) {
-            biomePackage.versionNumber()
+    override fun getCommentAccordingToStoredState(): ActionOnSaveComment? {
+        if (BiomeSettings.getInstance(project).configurationMode == ConfigurationMode.DISABLED) {
+            return ActionInfo.disabled()
         }
-        return ActionInfo.defaultComment(version, isActionOnSaveEnabled)
+
+        return null
+    }
+
+    override fun getCommentAccordingToUiState(configurable: BiomeConfigurable): ActionOnSaveComment? {
+        if (configurable.disabledConfiguration.isSelected) {
+            return ActionInfo.disabled()
+        }
+
+        return null
     }
 }

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeOnSaveFormatActionInfo.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeOnSaveFormatActionInfo.kt
@@ -1,11 +1,9 @@
 package com.github.biomejs.intellijbiome.settings
 
 import com.github.biomejs.intellijbiome.BiomeBundle
-import com.github.biomejs.intellijbiome.BiomePackage
 import com.intellij.ide.actionsOnSave.ActionOnSaveBackedByOwnConfigurable
 import com.intellij.ide.actionsOnSave.ActionOnSaveComment
 import com.intellij.ide.actionsOnSave.ActionOnSaveContext
-import com.intellij.platform.ide.progress.runWithModalProgressBlocking
 
 class BiomeOnSaveFormatActionInfo(actionOnSaveContext: ActionOnSaveContext) :
     ActionOnSaveBackedByOwnConfigurable<BiomeConfigurable>(
@@ -35,22 +33,19 @@ class BiomeOnSaveFormatActionInfo(actionOnSaveContext: ActionOnSaveContext) :
 
     override fun getActionLinks() = listOf(createGoToPageInSettingsLink(BiomeConfigurable.CONFIGURABLE_ID))
 
-    override fun getCommentAccordingToUiState(configurable: BiomeConfigurable): ActionOnSaveComment? {
-        return comment()
-    }
-
     override fun getCommentAccordingToStoredState(): ActionOnSaveComment? {
-        return comment()
-    }
-
-    private fun comment(): ActionOnSaveComment? {
-        if (!isSaveActionApplicable) return ActionOnSaveComment.info(BiomeBundle.message("biome.on.save.comment.disabled"))
-
-        val biomePackage = BiomePackage(project)
-        val version = runWithModalProgressBlocking(project, BiomeBundle.message("biome.version")) {
-            biomePackage.versionNumber()
+        if (BiomeSettings.getInstance(project).configurationMode == ConfigurationMode.DISABLED) {
+            return ActionInfo.disabled()
         }
 
-        return ActionInfo.defaultComment(version, isActionOnSaveEnabled)
+        return null
+    }
+
+    override fun getCommentAccordingToUiState(configurable: BiomeConfigurable): ActionOnSaveComment? {
+        if (configurable.disabledConfiguration.isSelected) {
+            return ActionInfo.disabled()
+        }
+
+        return null
     }
 }

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeOnSaveSortImportActionInfo.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeOnSaveSortImportActionInfo.kt
@@ -1,11 +1,9 @@
 package com.github.biomejs.intellijbiome.settings
 
 import com.github.biomejs.intellijbiome.BiomeBundle
-import com.github.biomejs.intellijbiome.BiomePackage
 import com.intellij.ide.actionsOnSave.ActionOnSaveBackedByOwnConfigurable
 import com.intellij.ide.actionsOnSave.ActionOnSaveComment
 import com.intellij.ide.actionsOnSave.ActionOnSaveContext
-import com.intellij.platform.ide.progress.runWithModalProgressBlocking
 
 class BiomeOnSaveSortImportActionInfo(actionOnSaveContext: ActionOnSaveContext) :
     ActionOnSaveBackedByOwnConfigurable<BiomeConfigurable>(
@@ -34,23 +32,21 @@ class BiomeOnSaveSortImportActionInfo(actionOnSaveContext: ActionOnSaveContext) 
         configurable.sortImportOnSaveCheckBox.isSelected = enabled
     }
 
-    override fun getCommentAccordingToUiState(configurable: BiomeConfigurable): ActionOnSaveComment? {
-        return comment()
-    }
-
-    override fun getCommentAccordingToStoredState(): ActionOnSaveComment? {
-        return comment()
-    }
-
     override fun getActionLinks() = listOf(createGoToPageInSettingsLink(BiomeConfigurable.CONFIGURABLE_ID))
 
-    private fun comment(): ActionOnSaveComment? {
-        if (!isSaveActionApplicable) return ActionOnSaveComment.info(BiomeBundle.message("biome.on.save.comment.disabled"))
-
-        val biomePackage = BiomePackage(project)
-        val version = runWithModalProgressBlocking(project, BiomeBundle.message("biome.version")) {
-            biomePackage.versionNumber()
+    override fun getCommentAccordingToStoredState(): ActionOnSaveComment? {
+        if (BiomeSettings.getInstance(project).configurationMode == ConfigurationMode.DISABLED) {
+            return ActionInfo.disabled()
         }
-        return ActionInfo.defaultComment(version, isActionOnSaveEnabled)
+
+        return null
+    }
+
+    override fun getCommentAccordingToUiState(configurable: BiomeConfigurable): ActionOnSaveComment? {
+        if (configurable.disabledConfiguration.isSelected) {
+            return ActionInfo.disabled()
+        }
+
+        return null
     }
 }

--- a/src/main/resources/messages/BiomeBundle.properties
+++ b/src/main/resources/messages/BiomeBundle.properties
@@ -27,8 +27,7 @@ biome.format.on.save.checkbox.on.actions.on.save.page=Run Biome format
 biome.apply.safe.fixes.on.save.checkbox.on.actions.on.save.page=Run Biome apply safe fixes
 biome.run.sort.import.on.save.checkbox.on.actions.on.save.page=Run Biome sort import
 biome.run.biome.check.with.features=Running Biome with {0}
-biome.run.on.save.package.not.specified.warning=Biome package not specified
-biome.run.on.save.version.and.files.pattern=Version {0}
+biome.run.on.save.disabled=Biome is disabled for this project
 biome.enable.lsp.format.help.label=<html>If LSP formatting is enabled, you can use it as a Save Action in IntelliJ:<ul> \
 <li>Open <b>Preferences/Settings</b> in IntelliJ.</li> \
 <li>Navigate to <b>Tools > Actions on Save</b>.</li> \


### PR DESCRIPTION
Fixes #205 

Removing the version indicator on the Actions on Save configuration page for the following reasons:

- It executes `biome --version` every time the UI is drawn, even on the panel is scrolled. This may cause glitches on some environment as #205.
- The plugin finds a Biome installation lazily on a file is opened, and multiple installations can be existed in a project.
- The Language Services panel in the toolbar already shows the version of Biome.