### PR TITLE
feat: disable Format on Save when LSP-based formatting is enabled

### DIFF
--- a/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeActionInfo.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeActionInfo.kt
@@ -10,5 +10,11 @@ class ActionInfo {
                 BiomeBundle.message("biome.run.on.save.disabled")
             )
         }
+
+        fun lspFormattingIsEnabled(): ActionOnSaveComment {
+            return ActionOnSaveComment.info(
+                BiomeBundle.message("biome.run.on.save.lspFormattingIsEnabled")
+            )
+        }
     }
 }

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeConfigurable.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeConfigurable.kt
@@ -168,7 +168,9 @@ class BiomeConfigurable(internal val project: Project) :
 
                 val link = ActionsOnSaveConfigurable.createGoToActionsOnSavePageLink()
                 cell(link)
-            }.enabledIf(!disabledConfiguration.selected)
+            }
+                .enabledIf(!disabledConfiguration.selected)
+                .visibleIf(!enableLspFormatCheckBox.selected)
 
             // *********************
             // Apply safe fixes on save row

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeOnSaveApplySafeFixesActionInfo.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeOnSaveApplySafeFixesActionInfo.kt
@@ -10,16 +10,19 @@ class BiomeOnSaveApplySafeFixesActionInfo(actionOnSaveContext: ActionOnSaveConte
         BiomeConfigurable.CONFIGURABLE_ID,
         BiomeConfigurable::class.java) {
 
+    private val settings
+        get() = BiomeSettings.getInstance(project)
+
     override fun getActionOnSaveName() =
         BiomeBundle.message("biome.apply.safe.fixes.on.save.checkbox.on.actions.on.save.page")
 
     override fun isApplicableAccordingToStoredState(): Boolean =
-        BiomeSettings.getInstance(project).configurationMode != ConfigurationMode.DISABLED
+        settings.configurationMode != ConfigurationMode.DISABLED
 
     override fun isApplicableAccordingToUiState(configurable: BiomeConfigurable): Boolean =
         !configurable.disabledConfiguration.isSelected
 
-    override fun isActionOnSaveEnabledAccordingToStoredState() = BiomeSettings.getInstance(project).applySafeFixesOnSave
+    override fun isActionOnSaveEnabledAccordingToStoredState() = settings.applySafeFixesOnSave
 
     override fun isActionOnSaveEnabledAccordingToUiState(configurable: BiomeConfigurable) =
         configurable.runSafeFixesOnSaveCheckBox.isSelected
@@ -32,7 +35,7 @@ class BiomeOnSaveApplySafeFixesActionInfo(actionOnSaveContext: ActionOnSaveConte
     override fun getActionLinks() = listOf(createGoToPageInSettingsLink(BiomeConfigurable.CONFIGURABLE_ID))
 
     override fun getCommentAccordingToStoredState(): ActionOnSaveComment? {
-        if (BiomeSettings.getInstance(project).configurationMode == ConfigurationMode.DISABLED) {
+        if (settings.configurationMode == ConfigurationMode.DISABLED) {
             return ActionInfo.disabled()
         }
 

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeOnSaveFormatActionInfo.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeOnSaveFormatActionInfo.kt
@@ -12,16 +12,19 @@ class BiomeOnSaveFormatActionInfo(actionOnSaveContext: ActionOnSaveContext) :
         BiomeConfigurable::class.java
     ) {
 
+    private val settings
+        get() = BiomeSettings.getInstance(project)
+
     override fun getActionOnSaveName() =
         BiomeBundle.message("biome.format.on.save.checkbox.on.actions.on.save.page")
 
     override fun isApplicableAccordingToStoredState(): Boolean =
-        BiomeSettings.getInstance(project).configurationMode != ConfigurationMode.DISABLED
+        settings.configurationMode != ConfigurationMode.DISABLED && !settings.enableLspFormat
 
-    override fun isActionOnSaveEnabledAccordingToStoredState() = BiomeSettings.getInstance(project).formatOnSave
+    override fun isActionOnSaveEnabledAccordingToStoredState() = settings.formatOnSave
 
     override fun isApplicableAccordingToUiState(configurable: BiomeConfigurable): Boolean =
-        !configurable.disabledConfiguration.isSelected
+        !configurable.disabledConfiguration.isSelected && !configurable.enableLspFormatCheckBox.isSelected
 
     override fun isActionOnSaveEnabledAccordingToUiState(configurable: BiomeConfigurable) =
         configurable.runFormatOnSaveCheckBox.isSelected
@@ -34,8 +37,12 @@ class BiomeOnSaveFormatActionInfo(actionOnSaveContext: ActionOnSaveContext) :
     override fun getActionLinks() = listOf(createGoToPageInSettingsLink(BiomeConfigurable.CONFIGURABLE_ID))
 
     override fun getCommentAccordingToStoredState(): ActionOnSaveComment? {
-        if (BiomeSettings.getInstance(project).configurationMode == ConfigurationMode.DISABLED) {
+        if (settings.configurationMode == ConfigurationMode.DISABLED) {
             return ActionInfo.disabled()
+        }
+
+        if (settings.enableLspFormat) {
+            return ActionInfo.lspFormattingIsEnabled()
         }
 
         return null
@@ -44,6 +51,10 @@ class BiomeOnSaveFormatActionInfo(actionOnSaveContext: ActionOnSaveContext) :
     override fun getCommentAccordingToUiState(configurable: BiomeConfigurable): ActionOnSaveComment? {
         if (configurable.disabledConfiguration.isSelected) {
             return ActionInfo.disabled()
+        }
+
+        if (configurable.enableLspFormatCheckBox.isSelected) {
+            return ActionInfo.lspFormattingIsEnabled()
         }
 
         return null

--- a/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeOnSaveSortImportActionInfo.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeOnSaveSortImportActionInfo.kt
@@ -12,17 +12,20 @@ class BiomeOnSaveSortImportActionInfo(actionOnSaveContext: ActionOnSaveContext) 
         BiomeConfigurable::class.java
     ) {
 
+    private val settings
+        get() = BiomeSettings.getInstance(project)
+
     override fun getActionOnSaveName() =
         BiomeBundle.message("biome.run.sort.import.on.save.checkbox.on.actions.on.save.page")
 
     override fun isApplicableAccordingToStoredState(): Boolean =
-        BiomeSettings.getInstance(project).configurationMode != ConfigurationMode.DISABLED
+        settings.configurationMode != ConfigurationMode.DISABLED
 
     override fun isApplicableAccordingToUiState(configurable: BiomeConfigurable): Boolean =
         !configurable.disabledConfiguration.isSelected
 
     override fun isActionOnSaveEnabledAccordingToStoredState() =
-        BiomeSettings.getInstance(project).sortImportOnSave
+        settings.sortImportOnSave
 
     override fun isActionOnSaveEnabledAccordingToUiState(configurable: BiomeConfigurable) =
         configurable.sortImportOnSaveCheckBox.isSelected
@@ -35,7 +38,7 @@ class BiomeOnSaveSortImportActionInfo(actionOnSaveContext: ActionOnSaveContext) 
     override fun getActionLinks() = listOf(createGoToPageInSettingsLink(BiomeConfigurable.CONFIGURABLE_ID))
 
     override fun getCommentAccordingToStoredState(): ActionOnSaveComment? {
-        if (BiomeSettings.getInstance(project).configurationMode == ConfigurationMode.DISABLED) {
+        if (settings.configurationMode == ConfigurationMode.DISABLED) {
             return ActionInfo.disabled()
         }
 

--- a/src/main/resources/messages/BiomeBundle.properties
+++ b/src/main/resources/messages/BiomeBundle.properties
@@ -28,6 +28,7 @@ biome.apply.safe.fixes.on.save.checkbox.on.actions.on.save.page=Run Biome apply 
 biome.run.sort.import.on.save.checkbox.on.actions.on.save.page=Run Biome sort import
 biome.run.biome.check.with.features=Running Biome with {0}
 biome.run.on.save.disabled=Biome is disabled for this project
+biome.run.on.save.lspFormattingIsEnabled=LSP-based code formatting is enabled
 biome.enable.lsp.format.help.label=<html>If LSP formatting is enabled, you can use it as a Save Action in IntelliJ:<ul> \
 <li>Open <b>Preferences/Settings</b> in IntelliJ.</li> \
 <li>Navigate to <b>Tools > Actions on Save</b>.</li> \


### PR DESCRIPTION
Changed the configuration panel to hide the Format on Save checkbox when the LSP-based formatting is enabled. This will reduce confusion and prevent running both LSP-based formatting and the classic Format on Save.

|Enabled|Disabled|
|---|---|
|<img width="1094" height="834" alt="image" src="https://github.com/user-attachments/assets/7b547374-746d-4589-9f8d-80d71c8157cd" />|<img width="1094" height="834" alt="image" src="https://github.com/user-attachments/assets/a2afabe8-3c53-4d78-be6d-dff4590b43ea" />|
