### PR TITLE
feat: add SVG file support

### DIFF
--- a/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeSettingsState.kt
+++ b/src/main/kotlin/com/github/biomejs/intellijbiome/settings/BiomeSettingsState.kt
@@ -26,7 +26,7 @@ class BiomeSettingsState : BaseState() {
     companion object {
         val DEFAULT_EXTENSION_LIST = listOf(
             ".astro", ".css", ".gql", ".graphql", ".js", ".mjs", ".cjs", ".jsx",
-            ".json", ".jsonc", ".svelte", ".html", ".ts", ".mts", ".cts", ".tsx", ".vue"
+            ".json", ".jsonc", ".svg", ".svelte", ".html", ".ts", ".mts", ".cts", ".tsx", ".vue"
         )
     }
 }


### PR DESCRIPTION
> This PR was written with AI assistance (Claude Code).

## Summary

Add support for `.svg` files in the IntelliJ plugin.

## Description

This PR adds `.svg` to the `DEFAULT_EXTENSION_LIST` so that Biome processes SVG files in IntelliJ-based IDEs by default.

Change in `BiomeSettingsState.kt`:
- Added `".svg"` to `DEFAULT_EXTENSION_LIST`.

Note: Users who have already customized their extension list in settings will not automatically pick up this change since their custom list overrides the default.

## Related

Related to biomejs/biome#9604 and biomejs/biome#9608.